### PR TITLE
Add marketing landing page, split resume into `resume.html`, and add SaaS transition docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Personal Resume
 
-This project renders an interactive résumé directly from YAML data. The page is pure HTML/CSS/JS and loads locale-specific content from `data/public`. A recruiter-facing public view is served by default with language selection in the header.
+This project currently includes a production-style landing page and an interactive résumé renderer powered by YAML data. The renderer is pure HTML/CSS/JS and loads locale-specific content from `data/public`, with language selection in the header.
 
 ## Structure
 
-- `index.html` – layout, markup, language switcher, and public view controls.
+- `index.html` – marketing landing page (Phase A entry point).
+- `resume.html` – recruiter-facing public resume renderer with language switcher.
 - `user.html` – editor login view and configuration panel.
 - `data/public/locales.yaml` – locale registry (code, label, resume path, and config path per language).
 - `data/public/config/*.yaml` – per-locale UI labels and language metadata.
@@ -21,7 +22,8 @@ This project renders an interactive résumé directly from YAML data. The page i
 
 1. Clone the repo and install Live Server (e.g. VS Code extension “Live Server” / “Five Server”).
 2. In VS Code right-click `index.html` → “Open with Live Server”. Alternatively run a static server (`npx serve .` or `python3 -m http.server`).
-3. Refresh the page after changing any YAML file – the app fetches locale files dynamically.
+3. Open `resume.html` to preview the resume renderer directly.
+4. Refresh the page after changing any YAML file – the app fetches locale files dynamically.
 
 ## Configuring the admin password
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,5 @@ Authoritative guides and workflows for maintaining the résumé project.
 - [Local Development Setup](guides/local-development.md)
 - [Content Update Workflow](guides/content-update-workflow.md)
 - [Deployment and QA Checklist](guides/deployment-qa.md)
+- [SaaS Transition Work Plan](guides/saas-transition-work-plan.md)
+- [Future Features Backlog](guides/future-features-backlog.md)

--- a/docs/guides/future-features-backlog.md
+++ b/docs/guides/future-features-backlog.md
@@ -1,0 +1,48 @@
+# Future Features Backlog
+
+This file tracks post-MVP ideas mentioned during product planning.
+
+## Metrics and insights
+
+- Public resume view count per link.
+- Weekly digest for resume owners.
+- High-level geographic insights (country level).
+
+## Recruiter panel
+
+- Recruiter accounts and role model.
+- Candidate bookmarking/saved profiles.
+- Private recruiter notes.
+- Candidate pipeline statuses.
+- Bulk export workflows.
+
+## Contact and scheduling
+
+- Public "request a conversation" action.
+- Candidate approve/ignore workflow.
+- Calendar integration.
+
+## Privacy and legal
+
+- Privacy policy page.
+- Terms of service page.
+- GDPR export/delete requests.
+- Unsubscribe preferences.
+
+## Internationalization expansion
+
+- Full app UI translation (EN/PL and beyond).
+- Locale-aware date/format handling.
+
+## Integrations
+
+- LinkedIn import research.
+- GitHub profile/activity enrichment.
+- Export to third-party formats.
+## AI-assisted resume intelligence
+
+- AI enrichment for ambiguous section detection after deterministic parsing baseline.
+- Confidence scoring for parsed entities (experience, education, skills).
+- Smart normalization of job titles, dates, and technology names.
+- Suggested improvements for ATS readability.
+

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -30,7 +30,8 @@ This guide explains how to run and iterate on the résumé locally.
    echo "ADMIN_PASSWORD=change-me" > data/private/user.env
    ```
 
-4. Start a static server from the repository root and open `index.html` in your browser.
+4. Start a static server from the repository root and open `index.html` for the landing page.
+5. Open `resume.html` when you want to test the resume renderer directly.
 
 ## Iterating on Content
 

--- a/docs/guides/saas-transition-work-plan.md
+++ b/docs/guides/saas-transition-work-plan.md
@@ -1,0 +1,263 @@
+# ResumeStudio SaaS Transition Work Plan
+
+This document translates product discussions into an execution plan optimized for fast, visible production progress.
+
+## 1) Confirmed product decisions
+
+The following decisions are locked and should be treated as implementation constraints:
+
+1. **One master resume per user** stored as structured data (YAML/JSON equivalent).
+2. **Multiple public links per user** are allowed through visibility configurations/presets.
+3. **Email verification is mandatory** from day one.
+4. **Disposable email protection is required** at signup using a **free external verification API**.
+5. **Multilingual support is a core requirement** (EN/PL now, DE/FR prepared in architecture).
+6. **User-controlled indexing** must be supported (indexable vs `noindex` per public resume).
+7. **Admin capabilities are required from initial releases** with full management scope.
+8. **Delivery priority is speed** with production-facing increments after every phase.
+9. **MVP target release date:** **May 31, 2026**.
+
+## 2) Current-state assessment (existing repository)
+
+Current strengths:
+
+- YAML-driven public resume rendering.
+- EN/PL locale support in content.
+- Section visibility controls (local mode).
+- Clean static deployment footprint.
+
+Current gaps versus target SaaS:
+
+- No multi-tenant accounts.
+- No per-user persistent backend model.
+- No upload/import pipeline.
+- No platform-level admin operations.
+- No secure public-link governance.
+
+## 3) Target architecture (MVP-first)
+
+- **Frontend:** Vite + React + TypeScript.
+- **API layer:** Netlify Functions.
+- **Data/Auth/Storage:** Supabase (PostgreSQL + Auth + Storage + RLS).
+- **Hosting:** Netlify.
+
+Implementation principle:
+
+- Keep and migrate the current renderer into a reusable `ResumeView` component.
+- Build product capabilities around this renderer without rewriting proven presentation logic.
+
+## 4) Phase plan with production-visible outcomes
+
+Each phase must be shipped on a dedicated branch and deployed to Netlify so progress is visible online.
+
+### Phase A — Public marketing launch first
+
+**Branch:** `feat/01-landing-live`
+
+Scope:
+
+- Build and deploy the new landing page at `/`.
+- Add clear CTA, product positioning, and waitlist/sign-up placeholder.
+- Keep app area inaccessible or marked as "coming next".
+
+Production outcome:
+
+- A professional, publicly visible product page is live immediately.
+
+Acceptance checks:
+
+- Netlify production URL shows new landing page.
+- Mobile/desktop layout QA passes.
+
+### Phase B — Auth foundation + anti-abuse
+
+**Branch:** `feat/02-auth-and-verification`
+
+Scope:
+
+- Supabase sign up/sign in/sign out/password reset.
+- Mandatory email verification.
+- Disposable-email domain blocking policy via free external API.
+- Protected routes in React Router.
+
+Production outcome:
+
+- Users can create verified accounts securely.
+
+Acceptance checks:
+
+- Unverified users cannot access protected features.
+- Disposable domains are blocked during signup.
+
+### Phase C — Data model + admin from day one
+
+**Branch:** `feat/03-schema-rls-admin-base`
+
+Scope:
+
+- Supabase migrations for profiles/resumes/configurations/public links/uploads.
+- RLS policies for owner-scoped access.
+- Admin role model and admin dashboard (user list + activate/deactivate + force password reset + moderation access).
+
+Production outcome:
+
+- Platform owner can fully manage users in production.
+
+Acceptance checks:
+
+- Admin routes are admin-only.
+- Data isolation works for regular users.
+- Admin actions are auditable.
+
+### Phase D — Master resume editor (single resume rule)
+
+**Branch:** `feat/04-master-resume-editor`
+
+Scope:
+
+- Multi-step editor storing one master resume per user.
+- Draft save + restore.
+- Review-and-publish flow.
+
+Production outcome:
+
+- Verified user can maintain their master resume online.
+
+Acceptance checks:
+
+- Exactly one active master resume is enforced per user.
+- Refresh does not lose in-progress data.
+
+### Phase E — Public resume links + indexing controls
+
+**Branch:** `feat/05-public-links-and-indexing`
+
+Scope:
+
+- Public route `/r/:slug` without authentication.
+- Default public link + additional links per visibility preset.
+- Per-link indexing setting (`index` / `noindex`) reflected in meta robots and headers where applicable.
+
+Production outcome:
+
+- Users can share tailored public resume versions.
+
+Acceptance checks:
+
+- Public links render correctly for anonymous visitors.
+- Indexing preference is reflected on the rendered page.
+
+### Phase F — Visibility configurator
+
+**Branch:** `feat/06-visibility-configurator`
+
+Scope:
+
+- Preset CRUD in user panel.
+- Mapping of visible sections/items per preset.
+- Link assignment to selected preset.
+
+Production outcome:
+
+- Users can prepare role-specific resume variants quickly.
+
+Acceptance checks:
+
+- Switching presets changes public content deterministically.
+
+### Phase G — Import pipeline (simple now) + AI expansion track
+
+**Branch:** `feat/07-import-pipeline`
+
+Scope:
+
+- File upload for PDF/image resumes.
+- Deterministic parsing baseline (text extraction + simple rule-based mapping).
+- Mandatory human review before save.
+
+Production outcome:
+
+- Users can bootstrap resume data from existing files faster.
+
+Acceptance checks:
+
+- Import flow works without AI dependency.
+- Parsing failures are visible and recoverable by manual edit.
+
+### Phase H — AI-assisted import enhancement
+
+**Branch:** `feat/08-ai-import-enhancement`
+
+Scope:
+
+- Add AI enrichment to improve extraction quality for ambiguous or complex CV layouts.
+- Keep AI call server-side only (Netlify Functions).
+- Add confidence indicators + fallback to deterministic output.
+
+Production outcome:
+
+- Better extraction quality while keeping manual control and predictable fallback.
+
+Acceptance checks:
+
+- AI path is optional and fails safely.
+- Deterministic parser remains functional as baseline.
+
+## 5) Milestone schedule (targeting May 31, 2026)
+
+- **By April 12, 2026:** Phase A live.
+- **By April 20, 2026:** Phase B live.
+- **By April 30, 2026:** Phase C live.
+- **By May 10, 2026:** Phase D live.
+- **By May 18, 2026:** Phase E live.
+- **By May 24, 2026:** Phase F live.
+- **By May 28, 2026:** Phase G live.
+- **By May 31, 2026:** Stabilization + release candidate for MVP.
+- **Post-MVP (June 2026+):** Phase H.
+
+## 6) Manual steps required from you (non-coding)
+
+1. Create Supabase project and store credentials securely:
+   - Project URL.
+   - Anon key.
+   - Service-role key (server only).
+2. Create Netlify site and connect repository.
+3. Set environment variables in Netlify and local `.env` files.
+4. Configure Supabase Auth:
+   - Site URL and redirect URLs.
+   - Email verification templates and behavior.
+5. Select and validate the free disposable-email verification API:
+   - Quotas/rate limits.
+   - SLA/reliability.
+   - Privacy and data-processing terms.
+6. Decide legal baseline pages owner/content:
+   - Privacy Policy.
+   - Terms of Service.
+7. Configure observability:
+   - Error monitoring (e.g., Sentry).
+   - Basic product analytics.
+8. Define support channel (email/help form).
+9. Define release acceptance routine:
+   - Test checklist per phase.
+   - Production smoke test after each merge.
+
+## 7) Branch and review workflow (mandatory)
+
+For every update:
+
+1. `git checkout -b feat/NN-short-name`
+2. Keep scope aligned to one phase only.
+3. Run local tests and smoke checks.
+4. Open PR with: scope, impact, risks, rollback.
+5. Merge only after review and successful preview deploy.
+6. Validate production after merge.
+
+## 8) Risks and controls
+
+- **Risk:** Scope creep before first value is visible.
+  - **Control:** Phase A must ship first and be publicly reachable.
+- **Risk:** Abuse via fake accounts.
+  - **Control:** Mandatory email verification + external disposable-email verification API.
+- **Risk:** Data leakage across tenants.
+  - **Control:** Strict RLS tests for `anon`, `authenticated`, and `admin` roles.
+- **Risk:** Parser quality issues.
+  - **Control:** Deterministic baseline parser + mandatory user review + AI enhancement only as additive layer.

--- a/index.html
+++ b/index.html
@@ -4,144 +4,73 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Łukasz Michta · Technical Writer</title>
+    <title>ResumeStudio · Build and share your professional resume</title>
+    <meta
+      name="description"
+      content="ResumeStudio helps professionals create one master resume, tailor public versions, and share role-specific links."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Homemade+Apple&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="styles/general.css" />
+    <link rel="stylesheet" href="styles/landing.css" />
   </head>
-  <body data-view-mode="public">
-    <div class="loading-indicator" id="app-loading-indicator" aria-live="polite" aria-hidden="true" hidden>
-      Loading resume data…
-    </div>
-    <div class="resume">
-        <header class="hero" aria-label="Profile summary">
-          <div class="hero__title">
-            <div class="logo-circle" id="brand-initials" aria-hidden="true"></div>
-            <div class="hero__identity">
-              <h1 id="name"></h1>
-              <p id="role"></p>
-            </div>
-          </div>
-          <div class="hero__actions">
-            <div class="hero__language">
-              <div
-                class="language-switcher"
-                id="language-switcher"
-                role="group"
-                aria-label="Language"
-              ></div>
-            </div>
-            <span class="public-view-badge" id="public-view-badge">Public view</span>
-            <a class="hero__login-button" id="edit-view-button" href="user.html">Edit</a>
-          </div>
-        </header>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="#" aria-label="ResumeStudio home">ResumeStudio</a>
+      <nav class="topbar__actions" aria-label="Primary">
+        <a class="btn btn--ghost" href="resume.html">Public preview</a>
+        <button class="btn btn--primary" type="button" disabled aria-disabled="true">Sign in (coming soon)</button>
+      </nav>
+    </header>
 
-      <main class="layout">
-        <section class="main-column" aria-label="Professional profile">
-          <article class="section" data-section="summary" aria-labelledby="summary-heading">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="summary-heading">Summary</h2>
-            </div>
-            <p id="summary" class="summary-text"></p>
-          </article>
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <p class="eyebrow">Fast, modern resume publishing</p>
+        <h1 id="hero-title">Create one master resume. Share tailored versions in seconds.</h1>
+        <p class="hero__lead">
+          ResumeStudio is becoming a full SaaS platform for professionals who want one source of truth for their career history
+          and multiple public links for role-specific applications.
+        </p>
+        <div class="hero__cta">
+          <button class="btn btn--primary" type="button" disabled aria-disabled="true">Get started free (coming soon)</button>
+          <a class="btn btn--ghost" href="resume.html">See live renderer</a>
+        </div>
+      </section>
 
-          <article class="section" data-section="github" id="github-activity-card" aria-labelledby="github-activity-heading">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="github-activity-heading">GitHub Activity</h2>
-            </div>
-            <a
-              id="github-activity-link"
-              class="github-activity__link"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <img
-                id="github-activity-image"
-                class="github-activity__image"
-                alt="GitHub activity"
-                loading="lazy"
-              />
-            </a>
-          </article>
+      <section class="features" aria-label="Key product capabilities">
+        <article class="feature-card">
+          <h2>Master resume model</h2>
+          <p>Maintain one up-to-date career record and selectively expose content by target role.</p>
+        </article>
+        <article class="feature-card">
+          <h2>Shareable public links</h2>
+          <p>Create default and role-specific public resume links from your visibility configurations.</p>
+        </article>
+        <article class="feature-card">
+          <h2>Import from existing CV</h2>
+          <p>Start with deterministic parsing first, then evolve with AI-assisted enrichment in later phases.</p>
+        </article>
+      </section>
 
-          <article class="section" data-section="experience" aria-labelledby="experience-heading">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="experience-heading">Experience</h2>
-            </div>
-            <div id="experience-list" class="timeline"></div>
-          </article>
+      <section class="timeline" aria-labelledby="timeline-title">
+        <h2 id="timeline-title">Roadmap status</h2>
+        <ol>
+          <li><strong>Live now:</strong> Landing page and public resume preview.</li>
+          <li><strong>Next:</strong> Account system with email verification and anti-temporary-email protection.</li>
+          <li><strong>Then:</strong> User dashboard, visibility presets, and public link controls.</li>
+        </ol>
+      </section>
+    </main>
 
-          <article class="section" data-section="education" aria-labelledby="education-heading">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="education-heading">Education</h2>
-            </div>
-            <div id="education-list" class="timeline timeline--compact"></div>
-          </article>
+    <footer class="footer">
+      <p>© <span id="current-year"></span> ResumeStudio. Built for modern job search workflows.</p>
+    </footer>
 
-          <article class="section" data-section="courses" aria-labelledby="courses-heading">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="courses-heading">Courses</h2>
-            </div>
-            <div id="courses-list" class="timeline timeline--compact timeline--courses"></div>
-          </article>
-        </section>
-
-        <aside class="sidebar" aria-label="Supporting information">
-          <section class="card" data-section="personal-info">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="personal-info-heading">Personal Info</h2>
-            </div>
-            <dl id="contact-list" class="contact-list"></dl>
-            <div id="qr-list" class="qr-list"></div>
-          </section>
-
-          <section class="card" data-section="skills">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="skills-heading">Skills</h2>
-            </div>
-            <div id="skills-list" class="meter-list"></div>
-          </section>
-
-          <section class="card" data-section="tech-stack">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="tech-stack-heading">Tech stack</h2>
-            </div>
-            <ul id="tech-stack" class="pill-list"></ul>
-          </section>
-
-          <section class="card" data-section="languages">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="languages-heading">Languages</h2>
-            </div>
-            <div id="languages-list" class="meter-list meter-list--compact"></div>
-          </section>
-
-          <section class="card" data-section="interests">
-            <div class="section-title">
-              <span class="section-dot" aria-hidden="true"></span>
-              <h2 id="interests-heading">Interests</h2>
-            </div>
-            <ul id="interests-list" class="pill-list"></ul>
-          </section>
-        </aside>
-      </main>
-    </div>
-
-    <script src="scripts/js-yaml.min.js"></script>
-    <script src="scripts/admin-config.js"></script>
-    <script src="scripts/main.js"></script>
+    <script>
+      document.getElementById('current-year').textContent = String(new Date().getFullYear());
+    </script>
   </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Łukasz Michta · Technical Writer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Homemade+Apple&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/general.css" />
+  </head>
+  <body data-view-mode="public">
+    <div class="loading-indicator" id="app-loading-indicator" aria-live="polite" aria-hidden="true" hidden>
+      Loading resume data…
+    </div>
+    <div class="resume">
+        <header class="hero" aria-label="Profile summary">
+          <div class="hero__title">
+            <div class="logo-circle" id="brand-initials" aria-hidden="true"></div>
+            <div class="hero__identity">
+              <h1 id="name"></h1>
+              <p id="role"></p>
+            </div>
+          </div>
+          <div class="hero__actions">
+            <div class="hero__language">
+              <div
+                class="language-switcher"
+                id="language-switcher"
+                role="group"
+                aria-label="Language"
+              ></div>
+            </div>
+            <span class="public-view-badge" id="public-view-badge">Public view</span>
+            <a class="hero__login-button" id="edit-view-button" href="user.html">Edit</a>
+          </div>
+        </header>
+
+      <main class="layout">
+        <section class="main-column" aria-label="Professional profile">
+          <article class="section" data-section="summary" aria-labelledby="summary-heading">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="summary-heading">Summary</h2>
+            </div>
+            <p id="summary" class="summary-text"></p>
+          </article>
+
+          <article class="section" data-section="github" id="github-activity-card" aria-labelledby="github-activity-heading">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="github-activity-heading">GitHub Activity</h2>
+            </div>
+            <a
+              id="github-activity-link"
+              class="github-activity__link"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <img
+                id="github-activity-image"
+                class="github-activity__image"
+                alt="GitHub activity"
+                loading="lazy"
+              />
+            </a>
+          </article>
+
+          <article class="section" data-section="experience" aria-labelledby="experience-heading">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="experience-heading">Experience</h2>
+            </div>
+            <div id="experience-list" class="timeline"></div>
+          </article>
+
+          <article class="section" data-section="education" aria-labelledby="education-heading">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="education-heading">Education</h2>
+            </div>
+            <div id="education-list" class="timeline timeline--compact"></div>
+          </article>
+
+          <article class="section" data-section="courses" aria-labelledby="courses-heading">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="courses-heading">Courses</h2>
+            </div>
+            <div id="courses-list" class="timeline timeline--compact timeline--courses"></div>
+          </article>
+        </section>
+
+        <aside class="sidebar" aria-label="Supporting information">
+          <section class="card" data-section="personal-info">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="personal-info-heading">Personal Info</h2>
+            </div>
+            <dl id="contact-list" class="contact-list"></dl>
+            <div id="qr-list" class="qr-list"></div>
+          </section>
+
+          <section class="card" data-section="skills">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="skills-heading">Skills</h2>
+            </div>
+            <div id="skills-list" class="meter-list"></div>
+          </section>
+
+          <section class="card" data-section="tech-stack">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="tech-stack-heading">Tech stack</h2>
+            </div>
+            <ul id="tech-stack" class="pill-list"></ul>
+          </section>
+
+          <section class="card" data-section="languages">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="languages-heading">Languages</h2>
+            </div>
+            <div id="languages-list" class="meter-list meter-list--compact"></div>
+          </section>
+
+          <section class="card" data-section="interests">
+            <div class="section-title">
+              <span class="section-dot" aria-hidden="true"></span>
+              <h2 id="interests-heading">Interests</h2>
+            </div>
+            <ul id="interests-list" class="pill-list"></ul>
+          </section>
+        </aside>
+      </main>
+    </div>
+
+    <script src="scripts/js-yaml.min.js"></script>
+    <script src="scripts/admin-config.js"></script>
+    <script src="scripts/main.js"></script>
+  </body>
+</html>

--- a/styles/landing.css
+++ b/styles/landing.css
@@ -1,0 +1,165 @@
+:root {
+  color-scheme: dark;
+  --bg: #070a14;
+  --bg-2: #0e1322;
+  --surface: rgba(255, 255, 255, 0.06);
+  --text: #f5f7ff;
+  --muted: #a5b0cf;
+  --primary: #6d8cff;
+  --primary-2: #9f7bff;
+  --border: rgba(255, 255, 255, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at 15% -10%, #26305f, transparent 42%), radial-gradient(circle at 95% 15%, #40205f, transparent 34%), var(--bg);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.topbar,
+main,
+.footer {
+  width: min(1080px, calc(100% - 3rem));
+  margin: 0 auto;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 0;
+}
+
+.brand {
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  font-size: 1.15rem;
+}
+
+.topbar__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 0.65rem 1.05rem;
+  border: 1px solid var(--border);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, opacity 120ms ease, background 120ms ease;
+}
+
+.btn--primary {
+  border: none;
+  color: #fff;
+  background: linear-gradient(90deg, var(--primary), var(--primary-2));
+}
+
+.btn--ghost {
+  background: var(--surface);
+}
+
+.btn[disabled] {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
+main {
+  padding: 2.5rem 0 4rem;
+}
+
+.hero {
+  max-width: 760px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #98a8ff;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+}
+
+h1 {
+  margin: 0.7rem 0 1rem;
+  line-height: 1.08;
+  font-size: clamp(2rem, 7vw, 3.6rem);
+}
+
+.hero__lead {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.hero__cta {
+  margin-top: 1.7rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.features {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.feature-card {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 16px;
+  padding: 1.15rem;
+}
+
+.feature-card h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.feature-card p {
+  margin: 0.65rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.timeline {
+  margin-top: 2.75rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.2rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.timeline h2 {
+  margin: 0 0 0.65rem;
+  font-size: 1.1rem;
+}
+
+.timeline ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 1.3rem 0 1.7rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
### Motivation
- Introduce a production-style marketing landing page as the Phase A entry point while keeping the interactive résumé renderer available for recruiters and QA.
- Capture product planning and roadmap artifacts for a planned SaaS transition and backlog of post-MVP features.

### Description
- Replace the previous `index.html` with a new landing page and move the original public resume renderer into a new `resume.html` file so the site can serve a marketing experience and a direct resume preview separately.
- Add a new stylesheet `styles/landing.css` and update `index.html` to reference it and use the `Inter` font and a landing-focused layout and components.
- Add documentation: the full `docs/guides/saas-transition-work-plan.md` work plan and a `docs/guides/future-features-backlog.md` backlog, and update `docs/README.md` and `README.md` and `docs/guides/local-development.md` to reference the landing page and new guidance.
- Preserve the existing resume renderer and its scripts in `resume.html` and keep the admin/test instructions and private config notes intact.

### Testing
- Ran the repository's automated test suite with `npm test` (jsdom-based regression checks for the admin login workflow), and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d028115630832db2213369f7abf92e)