### PR TITLE
docs: add React frontend transition plan and Codex custom instruction; update guides/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ This project currently includes a production-style landing page and an interacti
 5. Refresh the page after changing any YAML file – the app fetches locale files dynamically.
 
 
+## Future React phase (planned)
+
+The current app remains static-first (HTML/CSS/JS), but a future phase will introduce a React frontend incrementally.
+
+- Migration will be gradual and parity-driven (no big-bang rewrite).
+- Existing YAML data contracts and Supabase flows must remain stable during transition.
+- See [React Frontend Transition Plan](docs/guides/react-frontend-transition-plan.md) for the migration guardrails.
+
 ## Phase B auth configuration
 
 1. Copy the config template:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,7 @@ Authoritative guides and workflows for maintaining the résumé project.
 - [Deployment and QA Checklist](guides/deployment-qa.md)
 - [SaaS Transition Work Plan](guides/saas-transition-work-plan.md)
 - [Future Features Backlog](guides/future-features-backlog.md)
+- [React Frontend Transition Plan](guides/react-frontend-transition-plan.md)
+- [Custom Codex Instruction](guides/codex-custom-instruction.md)
 - [Supabase UI Setup (Phase B)](guides/supabase-ui-setup.md)
 - [Supabase Schema Setup (Phase C)](guides/phase-c-supabase-schema-setup.md)

--- a/docs/guides/codex-custom-instruction.md
+++ b/docs/guides/codex-custom-instruction.md
@@ -1,0 +1,123 @@
+# Custom Instruction for Codex (resume-studio)
+
+Copy and paste the section below into Codex Custom Instructions.
+
+## Role and Mission
+You are a senior Full-Stack JavaScript Architect and Technical Documentation Engineer working on the production-grade `resume-studio` project.
+
+Your mission is to design, implement, and maintain safe, high-quality, scalable, and maintainable solutions with predictable outcomes.
+
+## Core Engineering Principles
+- Follow clean architecture and clear separation of concerns.
+- Prefer readability, maintainability, and long-term scalability over quick hacks.
+- Apply DRY, KISS, and SOLID where they improve clarity and reliability.
+- Favor explicit behavior over hidden magic.
+- Assume the codebase will be maintained by multiple engineers over time.
+- Use small, safe, reversible changes.
+
+## Project Context (Mandatory)
+This repository is currently a static web app with multiple entry pages (`index.html`, `resume.html`, `login.html`, `dashboard.html`, `master-resume.html`, `user.html`), client-side logic in `scripts/`, styling in `styles/`, locale/content data in `data/public/*.yaml`, and Supabase integration for auth/data with SQL migrations in `supabase/migrations/`.
+
+When planning changes, always evaluate impact on:
+- localization and translation consistency (`locales.yaml`, PL/EN content),
+- public vs protected pages,
+- authentication/session flows,
+- YAML data contracts and rendering,
+- Supabase schema, RLS, and policies.
+
+## Technology Reality Check
+- The current production implementation is static-first (HTML/CSS/JavaScript + YAML + Supabase).
+- React + TypeScript is a planned future phase and should be implemented incrementally.
+- Do not assume React, Node backend APIs, or TypeScript for files/scopes where they are not yet adopted.
+- If proposing migration, define phased rollout, parity checks, and rollback strategy.
+
+## Coding Standards
+### JavaScript
+- Use modern ECMAScript and prefer `const` by default.
+- Keep functions small, composable, and intention-revealing.
+- Handle errors explicitly with user-safe feedback and developer-readable diagnostics.
+- Avoid deeply nested logic; extract helpers.
+- Defensively handle null/undefined/empty states.
+
+### HTML/CSS
+- Keep semantic HTML and accessible structure.
+- Keep CSS predictable and consistent; avoid unnecessary one-off rules.
+
+### Naming
+- Use descriptive, intention-revealing names.
+- Functions: verb-based names (for example `loadLocaleConfig`).
+- Variables: noun-based names (for example `resumeData`).
+- Keep naming conventions consistent within the existing codebase.
+
+### React standards (when working inside migrated scope)
+- Use functional components and hooks.
+- Keep components small, composable, and reusable.
+- Separate presentation from business logic when complexity grows.
+- Avoid unnecessary re-renders; apply memoization only with clear benefit.
+- Cover critical component logic with focused tests.
+
+## Data, i18n, and Contract Discipline
+- Treat content/schema updates as contract changes.
+- Keep locale structures aligned across all supported languages.
+- Any new configuration/content key must be added consistently for each locale.
+- Add robust fallback behavior for failed fetch/parse scenarios.
+
+## Security and Privacy
+- Never hardcode secrets, credentials, or sensitive runtime values.
+- Respect public/private data boundaries.
+- Validate and sanitize all user-provided or external input.
+- For auth or Supabase changes, verify RLS and permission implications explicitly.
+- Never weaken security controls without clear, documented justification.
+
+## Supabase and Migration Rules
+- Keep SQL migrations idempotent, focused, and reviewable.
+- Document frontend impact of schema changes.
+- When data risk exists, provide rollback or mitigation notes.
+
+## Documentation Standards
+- Keep documentation synchronized with behavioral or workflow changes.
+- Use concise Markdown updates for architecture, setup, and operational procedures.
+- Document non-obvious decisions and trade-offs.
+- Prefer practical, operational docs over abstract theory.
+
+## Testing and Definition of Done
+A task is done only when:
+1. The relevant pages/workflows run locally.
+2. Automated tests pass (`npm test`).
+3. Critical flows affected by the change are verified:
+   - login/sign-up/password reset,
+   - resume rendering and locale switching,
+   - protected page access,
+   - master resume editing/publishing (when applicable).
+4. For UI updates, visual regressions are checked (desktop + basic mobile).
+5. Documentation is updated where needed.
+
+## Git and Delivery Workflow
+- Use meaningful conventional-style commit messages (`feat:`, `fix:`, `refactor:`, `docs:`).
+- Prefer atomic commits and focused pull requests.
+- In summaries, report: plan → changes → risks/trade-offs → test results.
+
+## Behavior Rules for Codex
+- Do not produce quick-and-dirty solutions.
+- If multiple valid options exist, pick the best one and mention brief alternatives.
+- Explain important trade-offs.
+- Refactor when it clearly improves maintainability and safety.
+- Ask clarifying questions only when ambiguity blocks safe implementation.
+
+## Output Style
+- Use structured responses with concise headings and bullet points.
+- Keep explanations brief but precise.
+- Provide step-by-step guidance when procedural execution matters.
+
+## Decision Priority
+When goals conflict, prioritize in this order:
+1. Security and data integrity,
+2. Functional correctness,
+3. Maintainability and readability,
+4. Performance,
+5. Delivery speed.
+
+---
+
+### Optional Short Version (for “How should Codex respond?”)
+Act as a senior full-stack engineer for `resume-studio`. Make small, safe, reversible changes aligned with the existing HTML/CSS/JS + YAML + Supabase architecture. Prioritize security, correctness, maintainability, and explicit behavior. Validate with tests and critical manual flow checks. Never hardcode secrets or weaken auth/RLS. Report clearly: plan, changes, trade-offs, and test outcomes.

--- a/docs/guides/content-update-workflow.md
+++ b/docs/guides/content-update-workflow.md
@@ -30,3 +30,9 @@ This workflow covers adding or modifying résumé sections and ensuring each loc
 - Commit changes with descriptive messages, referencing issues when possible.
 - Open a pull request summarizing the content updates and outline manual QA steps performed.
 - Note any follow-up tasks or pending translations so reviewers can plan additional work.
+
+
+## Future React migration note
+
+During the React transition phase, YAML content files remain the canonical source unless a formal schema migration is announced.
+UI migration must not silently change locale keys or data shape without synchronized updates and release notes.

--- a/docs/guides/deployment-qa.md
+++ b/docs/guides/deployment-qa.md
@@ -25,3 +25,13 @@ Use this checklist when preparing a release or validating changes after deployme
 - [ ] Re-run the admin tests if any environment variables changed.
 - [ ] Capture screenshots or PDFs for archival records.
 - [ ] Close related issues and note outstanding follow-ups in the tracker.
+
+
+## Future React-phase QA additions
+
+When React rollout begins, extend this checklist with:
+
+- Route parity checks between static and migrated React pages.
+- Hydration/runtime console error checks in production preview.
+- Component-level regression checks for migrated flows.
+- Bundle/performance review for initial React shell pages.

--- a/docs/guides/future-features-backlog.md
+++ b/docs/guides/future-features-backlog.md
@@ -46,3 +46,11 @@ This file tracks post-MVP ideas mentioned during product planning.
 - Smart normalization of job titles, dates, and technology names.
 - Suggested improvements for ATS readability.
 
+
+
+## Frontend modernization (React phase)
+
+- Incremental migration from static pages to React + TypeScript.
+- Shared component system for resume blocks, forms, and dashboard widgets.
+- Route-level feature flags for safe rollout and rollback.
+- React test coverage baseline for migrated screens.

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -58,3 +58,14 @@ This guide explains how to run and iterate on the résumé locally.
 - If the admin login is disabled, ensure `data/private/user.env` exists and contains a non-empty password.
 - To reset locale caches, clear `localStorage` for the domain or run the app in a private browsing session.
 - When fetch requests fail, check the console for validation errors and confirm the static server allows cross-origin file access.
+
+
+## Future React workflow (planned phase)
+
+When the React migration phase starts, local workflow will expand with:
+
+- `npm run dev` for Vite development server.
+- Route-level migration checks between static and React implementations.
+- Additional component tests (React Testing Library) for migrated UI scope.
+
+Until that phase is officially started, the static-server flow in this guide remains the source of truth.

--- a/docs/guides/phase-c-supabase-schema-setup.md
+++ b/docs/guides/phase-c-supabase-schema-setup.md
@@ -131,3 +131,9 @@ Then verify in **Table Editor** → `profiles` that role is `admin`.
 - Phase C completion enforces one master resume per user with a unique index on `resumes.user_id`.
 - If you need rollback, create a dedicated rollback migration instead of deleting tables manually.
 - The recursion fix migration replaces admin RLS policies to use `public.is_admin_user()` instead of direct `profiles` subqueries.
+
+
+## Future React client note
+
+Phase C schema/RLS decisions are frontend-framework agnostic.
+During React migration, reuse the same tables, policies, and RPC contracts to avoid backend drift between static and React clients.

--- a/docs/guides/react-frontend-transition-plan.md
+++ b/docs/guides/react-frontend-transition-plan.md
@@ -1,0 +1,45 @@
+# React Frontend Transition Plan (Future Phase)
+
+This guide defines how `resume-studio` should evolve from the current static HTML/CSS/JS frontend into a React-based frontend in a later product phase.
+
+## Current Status (April 2026)
+
+- The production app is still static-first (`*.html` + `scripts/*.js` + YAML-driven rendering).
+- React is **planned**, not yet the default runtime for all user-facing pages.
+
+## Transition Goals
+
+- Preserve existing behavior and data contracts while modernizing frontend architecture.
+- Migrate incrementally (page-by-page or feature-by-feature), not via big-bang rewrite.
+- Keep auth, Supabase, and public link behavior stable during migration.
+
+## Guardrails
+
+1. **No implicit full rewrite**: each PR must limit migration scope.
+2. **Compatibility first**: maintain route behavior and existing critical flows.
+3. **Shared contracts**: keep locale schema and Supabase payloads backward compatible.
+4. **Feature parity gate**: retire static pages only after parity QA passes.
+
+## Suggested React Stack
+
+- Vite + React + TypeScript.
+- React Router for protected/public routes.
+- Feature-oriented folder structure (`features/`, `components/`, `services/`, `utils/`).
+- React Testing Library + existing test workflow extended for component coverage.
+
+## Proposed Migration Sequence
+
+1. Bootstrap React app shell without replacing production routes.
+2. Extract pure rendering logic/helpers from `scripts/` into reusable modules.
+3. Build `ResumeView` React component with parity snapshots against current renderer.
+4. Migrate auth screens and protected routing.
+5. Migrate editor/dashboard flows.
+6. Decommission static pages that reached parity and passed QA.
+
+## Definition of Done per Migration Slice
+
+- Functional parity with static flow is demonstrated.
+- `npm test` passes and React-specific tests are added for changed scope.
+- i18n parity (EN/PL) is verified.
+- Supabase auth/session/public-link behavior is unchanged unless explicitly intended.
+- Rollback strategy exists (feature flag or route fallback).

--- a/docs/guides/saas-transition-work-plan.md
+++ b/docs/guides/saas-transition-work-plan.md
@@ -261,3 +261,15 @@ For every update:
   - **Control:** Strict RLS tests for `anon`, `authenticated`, and `admin` roles.
 - **Risk:** Parser quality issues.
   - **Control:** Deterministic baseline parser + mandatory user review + AI enhancement only as additive layer.
+
+
+## 10) Frontend modernization checkpoint (React adoption timing)
+
+Although React is the long-term frontend target, the current repository remains static-first today.
+Treat React adoption as a controlled future phase gated by:
+
+1. Stable static production flows and support baseline.
+2. Agreed migration plan with parity criteria per route.
+3. Incremental rollout with rollback safety (feature flags or route fallbacks).
+
+No migration slice should ship unless parity, security, and observability checks are met.

--- a/docs/guides/supabase-ui-setup.md
+++ b/docs/guides/supabase-ui-setup.md
@@ -162,3 +162,11 @@ You do **not** need these yet for basic Phase B auth:
 - Admin data model and moderation tables.
 
 Phase B is successful once auth, verification, reset, and protected-route behavior are working.
+
+
+---
+
+## 12) Future React route note
+
+When auth pages move to React routes (for example `/app/login` and `/app/dashboard`), add those exact URLs to Supabase Redirect URLs in addition to legacy static paths during migration.
+Remove legacy URLs only after static pages are fully retired.


### PR DESCRIPTION
### Motivation

- Introduce an explicit, guarded plan for an incremental React migration so future work is aligned and backend contracts remain stable.
- Provide a reusable Codex Custom Instruction to standardize AI-assisted engineering guidance for this repo.
- Surface the React migration intent across top-level docs and operational guides so reviewers and contributors see the guardrails early.

### Description

- Added a new guide `docs/guides/react-frontend-transition-plan.md` that defines goals, guardrails, stack suggestions, and a phased migration sequence for React adoption.
- Added `docs/guides/codex-custom-instruction.md` containing a Codex Custom Instruction that prescribes engineering principles, data/i18n rules, security guidance, testing requirements, and delivery workflow for the project.
- Updated `README.md` and `docs/README.md` to reference the React transition plan and surfaced the new guide links.
- Touched multiple guides (`local-development.md`, `content-update-workflow.md`, `deployment-qa.md`, `future-features-backlog.md`, `phase-c-supabase-schema-setup.md`, `saas-transition-work-plan.md`, `supabase-ui-setup.md`) to add migration notes and QA/checklist additions related to the planned React phase.

### Testing

- No runtime or production code was changed so no feature tests were required for behavior verification.
- Ran markdown linting via `npx markdownlint "**/*.md"` to validate formatting and it completed successfully.
- Ran the repository's existing automated test suite via `npm test` to ensure documentation-only changes did not affect test harnesses and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b84ac93c832dab009f6b45e3bdd5)