### PR TITLE
Split Supabase envs for preview/prod and enforce email verification in legacy auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCVHub
 
-This repository contains the legacy static OpenCVHub app and the in-progress Next.js SaaS rebuild.
+This repository contains the legacy static OpenCVHub app and the in-progress Next.js SaaS rebuild...
 
 ## Structure
 

--- a/docs/guides/environment-matrix.md
+++ b/docs/guides/environment-matrix.md
@@ -30,6 +30,31 @@ Templates:
 - `.env.preview.example`
 - `.env.production.example`
 
+## Supabase project split (production vs preview/local)
+
+Use separate Supabase projects:
+
+- **Production deploy** (`main` on Netlify) → production Supabase project.
+- **Deploy Preview** (PR builds on Netlify) → test Supabase project.
+- **Local development** (`npm run dev`) → test Supabase project.
+
+For the Next.js app (`/login`, `/dashboard`, API routes), this split is handled by Netlify environment scoping:
+
+- Production scope values should point to production Supabase.
+- Deploy Previews scope values should point to test Supabase.
+- Local `.env.local` (based on `.env.development.example`) should point to test Supabase.
+
+For legacy static auth pages (`login.html`, `dashboard.html`) configure `window.RESUME_STUDIO_AUTH_ENV` (see `scripts/auth-config.example.js`) and set:
+
+- `production.supabaseUrl` / `production.supabaseAnonKey` → production.
+- `preview.*` and `development.*` → test.
+
+Runtime host detection in `scripts/auth-config.js` maps:
+
+- `localhost` / `127.0.0.1` → `development`
+- `*.netlify.app` preview-like hosts (for example `deploy-preview-*` or branch aliases) → `preview`
+- all other hosts → `production`
+
 ## CI Policy
 
 GitHub Actions workflow `ci.yml` runs on PR and push to `main/master`:

--- a/scripts/auth-config.example.js
+++ b/scripts/auth-config.example.js
@@ -1,7 +1,14 @@
-window.RESUME_STUDIO_CONFIG = {
-  supabaseUrl: 'https://YOUR_PROJECT.supabase.co',
-  supabaseAnonKey: 'YOUR_PUBLIC_ANON_KEY',
-  appRedirectUrl: 'http://localhost:8000/dashboard.html',
-  emailVerificationRedirectUrl: 'http://localhost:8000/login.html',
-  passwordResetRedirectUrl: 'http://localhost:8000/login.html'
+window.RESUME_STUDIO_AUTH_ENV = {
+  production: {
+    supabaseUrl: 'https://YOUR_PRODUCTION_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_PRODUCTION_PUBLIC_ANON_KEY'
+  },
+  preview: {
+    supabaseUrl: 'https://YOUR_TEST_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_TEST_PUBLIC_ANON_KEY'
+  },
+  development: {
+    supabaseUrl: 'https://YOUR_TEST_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_TEST_PUBLIC_ANON_KEY'
+  }
 };

--- a/scripts/auth-config.js
+++ b/scripts/auth-config.js
@@ -1,7 +1,27 @@
-window.RESUME_STUDIO_CONFIG = window.RESUME_STUDIO_CONFIG || {
-  supabaseUrl: 'https://ypzlxhhhvnffnxebutgw.supabase.co',
-  supabaseAnonKey: 'sb_publishable_f4h3-2o26Q18WtNrELozyw_RRCPpDTu',
-  appRedirectUrl: `${window.location.origin}/dashboard.html`,
-  emailVerificationRedirectUrl: `${window.location.origin}/login.html`,
-  passwordResetRedirectUrl: `${window.location.origin}/login.html`
-};
+(function initLegacyAuthConfig() {
+  const existingConfig = window.RESUME_STUDIO_CONFIG;
+  if (existingConfig?.supabaseUrl && existingConfig?.supabaseAnonKey) {
+    return;
+  }
+
+  const host = window.location.hostname.toLowerCase();
+  const isLocalHost = host === 'localhost' || host === '127.0.0.1';
+  const isNetlifyHost = host.endsWith('.netlify.app');
+  const isPreviewHost =
+    isNetlifyHost && (host.includes('deploy-preview') || host.includes('--'));
+
+  const runtimeEnv = window.RESUME_STUDIO_AUTH_ENV || {};
+  const environment = isLocalHost ? 'development' : isPreviewHost ? 'preview' : 'production';
+
+  const environmentConfig = runtimeEnv[environment] || {};
+  const fallbackConfig = runtimeEnv.default || {};
+
+  window.RESUME_STUDIO_CONFIG = {
+    supabaseUrl: environmentConfig.supabaseUrl || fallbackConfig.supabaseUrl || '',
+    supabaseAnonKey: environmentConfig.supabaseAnonKey || fallbackConfig.supabaseAnonKey || '',
+    appRedirectUrl: `${window.location.origin}/dashboard.html`,
+    emailVerificationRedirectUrl: `${window.location.origin}/login.html`,
+    passwordResetRedirectUrl: `${window.location.origin}/login.html`,
+    appEnvironment: environment
+  };
+})();

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -11,7 +11,8 @@
   const supabaseAnonKey = config.supabaseAnonKey;
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    setStatus('Supabase config missing. Update scripts/auth-config.js first.', true);
+    const environment = config.appEnvironment || 'unknown';
+    setStatus(`Supabase config missing for "${environment}" environment. Update scripts/auth-config.js first.`, true);
     toggleFormAvailability(true);
     return;
   }
@@ -74,6 +75,13 @@
       } = await client.auth.getUser();
 
       if (user?.id) {
+        if (!user.email_confirmed_at) {
+          await client.auth.signOut();
+          setStatus('Email verification is required before sign in.', true);
+          showResendVerification(Boolean(email));
+          return;
+        }
+
         const { data: profile, error: profileError } = await client
           .from('profiles')
           .select('is_active')


### PR DESCRIPTION
### Motivation

- Keep production data isolated by using separate Supabase projects for production vs preview/local builds.  
- Make legacy static auth pages compatible with the multi-project setup by selecting credentials at runtime.  
- Improve account security and UX by blocking sign-in for unverified emails and prompting resend verification.

### Description

- Added documentation in `docs/guides/environment-matrix.md` describing the Supabase project split and runtime host-to-environment mapping.  
- Replaced the single legacy config example with `window.RESUME_STUDIO_AUTH_ENV` in `scripts/auth-config.example.js` to provide `production`, `preview`, and `development` credential sets.  
- Reworked `scripts/auth-config.js` to detect host (`localhost`, Netlify preview hosts, or production), select the appropriate environment config from `window.RESUME_STUDIO_AUTH_ENV`, populate `window.RESUME_STUDIO_CONFIG`, and include `appEnvironment` for diagnostics.  
- Updated `scripts/auth.js` to show the detected environment in the missing-config status message and to require `user.email_confirmed_at` during sign-in, signing users out and prompting resend when email verification is missing.

### Testing

- CI steps `npm ci`, `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build` were executed as the repository CI policy; all checks passed.  
- Legacy auth flows were covered by automated tests present in the test suite and they passed under the updated configuration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2928457c832d96dac3223358caf6)