### PR TITLE
Gate cookie domain by app env; add legacy auth env mapping and require email verification

### DIFF
--- a/app/lib/auth-cookies.ts
+++ b/app/lib/auth-cookies.ts
@@ -25,6 +25,11 @@ type AuthTokens = {
 };
 
 function getCookieDomain(): string | undefined {
+  const appEnvironment = process.env.NEXT_PUBLIC_APP_ENV;
+  if (appEnvironment && appEnvironment !== "production") {
+    return undefined;
+  }
+
   const configuredDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
   return configuredDomain ? configuredDomain : undefined;
 }

--- a/docs/guides/environment-matrix.md
+++ b/docs/guides/environment-matrix.md
@@ -30,6 +30,31 @@ Templates:
 - `.env.preview.example`
 - `.env.production.example`
 
+## Supabase project split (production vs preview/local)
+
+Use separate Supabase projects:
+
+- **Production deploy** (`main` on Netlify) → production Supabase project.
+- **Deploy Preview** (PR builds on Netlify) → test Supabase project.
+- **Local development** (`npm run dev`) → test Supabase project.
+
+For the Next.js app (`/login`, `/dashboard`, API routes), this split is handled by Netlify environment scoping:
+
+- Production scope values should point to production Supabase.
+- Deploy Previews scope values should point to test Supabase.
+- Local `.env.local` (based on `.env.development.example`) should point to test Supabase.
+
+For legacy static auth pages (`login.html`, `dashboard.html`) configure `window.RESUME_STUDIO_AUTH_ENV` (see `scripts/auth-config.example.js`) and set:
+
+- `production.supabaseUrl` / `production.supabaseAnonKey` → production.
+- `preview.*` and `development.*` → test.
+
+Runtime host detection in `scripts/auth-config.js` maps:
+
+- `localhost` / `127.0.0.1` → `development`
+- `*.netlify.app` preview-like hosts (for example `deploy-preview-*` or branch aliases) → `preview`
+- all other hosts → `production`
+
 ## CI Policy
 
 GitHub Actions workflow `ci.yml` runs on PR and push to `main/master`:

--- a/scripts/auth-config.example.js
+++ b/scripts/auth-config.example.js
@@ -1,7 +1,14 @@
-window.RESUME_STUDIO_CONFIG = {
-  supabaseUrl: 'https://YOUR_PROJECT.supabase.co',
-  supabaseAnonKey: 'YOUR_PUBLIC_ANON_KEY',
-  appRedirectUrl: 'http://localhost:8000/dashboard.html',
-  emailVerificationRedirectUrl: 'http://localhost:8000/login.html',
-  passwordResetRedirectUrl: 'http://localhost:8000/login.html'
+window.RESUME_STUDIO_AUTH_ENV = {
+  production: {
+    supabaseUrl: 'https://YOUR_PRODUCTION_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_PRODUCTION_PUBLIC_ANON_KEY'
+  },
+  preview: {
+    supabaseUrl: 'https://YOUR_TEST_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_TEST_PUBLIC_ANON_KEY'
+  },
+  development: {
+    supabaseUrl: 'https://YOUR_TEST_PROJECT.supabase.co',
+    supabaseAnonKey: 'YOUR_TEST_PUBLIC_ANON_KEY'
+  }
 };

--- a/scripts/auth-config.js
+++ b/scripts/auth-config.js
@@ -1,7 +1,27 @@
-window.RESUME_STUDIO_CONFIG = window.RESUME_STUDIO_CONFIG || {
-  supabaseUrl: 'https://ypzlxhhhvnffnxebutgw.supabase.co',
-  supabaseAnonKey: 'sb_publishable_f4h3-2o26Q18WtNrELozyw_RRCPpDTu',
-  appRedirectUrl: `${window.location.origin}/dashboard.html`,
-  emailVerificationRedirectUrl: `${window.location.origin}/login.html`,
-  passwordResetRedirectUrl: `${window.location.origin}/login.html`
-};
+(function initLegacyAuthConfig() {
+  const existingConfig = window.RESUME_STUDIO_CONFIG;
+  if (existingConfig?.supabaseUrl && existingConfig?.supabaseAnonKey) {
+    return;
+  }
+
+  const host = window.location.hostname.toLowerCase();
+  const isLocalHost = host === 'localhost' || host === '127.0.0.1';
+  const isNetlifyHost = host.endsWith('.netlify.app');
+  const isPreviewHost =
+    isNetlifyHost && (host.includes('deploy-preview') || host.includes('--'));
+
+  const runtimeEnv = window.RESUME_STUDIO_AUTH_ENV || {};
+  const environment = isLocalHost ? 'development' : isPreviewHost ? 'preview' : 'production';
+
+  const environmentConfig = runtimeEnv[environment] || {};
+  const fallbackConfig = runtimeEnv.default || {};
+
+  window.RESUME_STUDIO_CONFIG = {
+    supabaseUrl: environmentConfig.supabaseUrl || fallbackConfig.supabaseUrl || '',
+    supabaseAnonKey: environmentConfig.supabaseAnonKey || fallbackConfig.supabaseAnonKey || '',
+    appRedirectUrl: `${window.location.origin}/dashboard.html`,
+    emailVerificationRedirectUrl: `${window.location.origin}/login.html`,
+    passwordResetRedirectUrl: `${window.location.origin}/login.html`,
+    appEnvironment: environment
+  };
+})();

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -11,7 +11,8 @@
   const supabaseAnonKey = config.supabaseAnonKey;
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    setStatus('Supabase config missing. Update scripts/auth-config.js first.', true);
+    const environment = config.appEnvironment || 'unknown';
+    setStatus(`Supabase config missing for "${environment}" environment. Update scripts/auth-config.js first.`, true);
     toggleFormAvailability(true);
     return;
   }
@@ -74,6 +75,13 @@
       } = await client.auth.getUser();
 
       if (user?.id) {
+        if (!user.email_confirmed_at) {
+          await client.auth.signOut();
+          setStatus('Email verification is required before sign in.', true);
+          showResendVerification(Boolean(email));
+          return;
+        }
+
         const { data: profile, error: profileError } = await client
           .from('profiles')
           .select('is_active')

--- a/tests/auth-cookies.test.mjs
+++ b/tests/auth-cookies.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { setAuthCookies } from "../app/lib/auth-cookies.ts";
+
+function buildCookieStore() {
+  const writes = [];
+  return {
+    writes,
+    get() {
+      return undefined;
+    },
+    set(name, value, options) {
+      writes.push({ name, value, options });
+    },
+  };
+}
+
+function buildSession() {
+  return {
+    access_token: "access-token",
+    refresh_token: "refresh-token",
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    user: {
+      id: "user-id",
+    },
+  };
+}
+
+test("setAuthCookies keeps host-only cookies outside production app env", () => {
+  const previousAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
+  const previousCookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+  process.env.NEXT_PUBLIC_APP_ENV = "preview";
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = "opencvhub.netlify.app";
+
+  const cookieStore = buildCookieStore();
+  setAuthCookies(cookieStore, buildSession());
+
+  assert.equal(cookieStore.writes.length, 2);
+  assert.equal(cookieStore.writes[0].options?.domain, undefined);
+  assert.equal(cookieStore.writes[1].options?.domain, undefined);
+
+  process.env.NEXT_PUBLIC_APP_ENV = previousAppEnv;
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = previousCookieDomain;
+});
+
+test("setAuthCookies applies configured cookie domain in production app env", () => {
+  const previousAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
+  const previousCookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+  process.env.NEXT_PUBLIC_APP_ENV = "production";
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = "opencvhub.netlify.app";
+
+  const cookieStore = buildCookieStore();
+  setAuthCookies(cookieStore, buildSession());
+
+  assert.equal(cookieStore.writes.length, 2);
+  assert.equal(cookieStore.writes[0].options?.domain, "opencvhub.netlify.app");
+  assert.equal(cookieStore.writes[1].options?.domain, "opencvhub.netlify.app");
+
+  process.env.NEXT_PUBLIC_APP_ENV = previousAppEnv;
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = previousCookieDomain;
+});


### PR DESCRIPTION
### Motivation
- Prevent host-scoped cookies from being set in non-production environments by ensuring cookie domain is only applied for the production app environment.
- Provide a clearer environment split for Supabase projects (production vs preview/local) and make legacy static auth pages configurable by runtime environment.
- Harden legacy auth pages by enforcing email verification before completing sign-in.

### Description
- Added `getCookieDomain()` in `app/lib/auth-cookies.ts` to return `undefined` when `NEXT_PUBLIC_APP_ENV` is present and not `production`, and used it when setting auth cookies.
- Updated documentation in `docs/guides/environment-matrix.md` to describe Supabase project splitting and runtime host detection rules.
- Reworked legacy auth configuration: `scripts/auth-config.example.js` now exposes `window.RESUME_STUDIO_AUTH_ENV` with `production/preview/development` keys, and `scripts/auth-config.js` now initializes `window.RESUME_STUDIO_CONFIG` at runtime by detecting host and selecting the appropriate env values (and sets `appEnvironment`).
- Enhanced `scripts/auth.js` to include the environment name in the missing-config message and to block sign-in if the user has not confirmed their email (signs out and shows resend UI).
- Added unit tests `tests/auth-cookies.test.mjs` to assert cookie domain behavior for preview vs production app environments.

### Testing
- Ran unit tests via `npm test`, including the newly added `tests/auth-cookies.test.mjs`, and they all passed.
- The new `auth-cookies` tests verify that cookie domain is omitted in non-production `NEXT_PUBLIC_APP_ENV` and applied when `NEXT_PUBLIC_APP_ENV=production`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2928457c832d96dac3223358caf6)