### PR TITLE
fix: prevent preview login redirect loop by scoping auth cookies to production only

### DIFF
--- a/app/lib/auth-cookies.ts
+++ b/app/lib/auth-cookies.ts
@@ -24,9 +24,18 @@ type AuthTokens = {
   refreshToken: string | null;
 };
 
+function isProductionCookieScope(): boolean {
+  const appEnvironment = (process.env.NEXT_PUBLIC_APP_ENV || "").toLowerCase();
+  if (appEnvironment) {
+    return appEnvironment === "production";
+  }
+
+  const deployContext = (process.env.CONTEXT || process.env.VERCEL_ENV || "").toLowerCase();
+  return deployContext === "production";
+}
+
 function getCookieDomain(): string | undefined {
-  const appEnvironment = process.env.NEXT_PUBLIC_APP_ENV;
-  if (appEnvironment && appEnvironment !== "production") {
+  if (!isProductionCookieScope()) {
     return undefined;
   }
 

--- a/tests/auth-cookies.test.mjs
+++ b/tests/auth-cookies.test.mjs
@@ -29,36 +29,100 @@ function buildSession() {
   };
 }
 
+function withEnv(patch, callback) {
+  const keys = Object.keys(patch);
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+  try {
+    for (const key of keys) {
+      const value = patch[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    callback();
+  } finally {
+    for (const key of keys) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 test("setAuthCookies keeps host-only cookies outside production app env", () => {
-  const previousAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
-  const previousCookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
-  process.env.NEXT_PUBLIC_APP_ENV = "preview";
-  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = "opencvhub.netlify.app";
+  withEnv(
+    {
+      NEXT_PUBLIC_APP_ENV: "preview",
+      CONTEXT: "deploy-preview",
+      NEXT_PUBLIC_COOKIE_DOMAIN: "opencvhub.netlify.app",
+    },
+    () => {
+      const cookieStore = buildCookieStore();
+      setAuthCookies(cookieStore, buildSession());
 
-  const cookieStore = buildCookieStore();
-  setAuthCookies(cookieStore, buildSession());
+      assert.equal(cookieStore.writes.length, 2);
+      assert.equal(cookieStore.writes[0].options?.domain, undefined);
+      assert.equal(cookieStore.writes[1].options?.domain, undefined);
+    },
+  );
+});
 
-  assert.equal(cookieStore.writes.length, 2);
-  assert.equal(cookieStore.writes[0].options?.domain, undefined);
-  assert.equal(cookieStore.writes[1].options?.domain, undefined);
+test("setAuthCookies keeps host-only cookies for preview when app env is missing", () => {
+  withEnv(
+    {
+      NEXT_PUBLIC_APP_ENV: undefined,
+      CONTEXT: "deploy-preview",
+      NEXT_PUBLIC_COOKIE_DOMAIN: "opencvhub.netlify.app",
+    },
+    () => {
+      const cookieStore = buildCookieStore();
+      setAuthCookies(cookieStore, buildSession());
 
-  process.env.NEXT_PUBLIC_APP_ENV = previousAppEnv;
-  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = previousCookieDomain;
+      assert.equal(cookieStore.writes.length, 2);
+      assert.equal(cookieStore.writes[0].options?.domain, undefined);
+      assert.equal(cookieStore.writes[1].options?.domain, undefined);
+    },
+  );
 });
 
 test("setAuthCookies applies configured cookie domain in production app env", () => {
-  const previousAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
-  const previousCookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
-  process.env.NEXT_PUBLIC_APP_ENV = "production";
-  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = "opencvhub.netlify.app";
+  withEnv(
+    {
+      NEXT_PUBLIC_APP_ENV: "production",
+      CONTEXT: "production",
+      NEXT_PUBLIC_COOKIE_DOMAIN: "opencvhub.netlify.app",
+    },
+    () => {
+      const cookieStore = buildCookieStore();
+      setAuthCookies(cookieStore, buildSession());
 
-  const cookieStore = buildCookieStore();
-  setAuthCookies(cookieStore, buildSession());
+      assert.equal(cookieStore.writes.length, 2);
+      assert.equal(cookieStore.writes[0].options?.domain, "opencvhub.netlify.app");
+      assert.equal(cookieStore.writes[1].options?.domain, "opencvhub.netlify.app");
+    },
+  );
+});
 
-  assert.equal(cookieStore.writes.length, 2);
-  assert.equal(cookieStore.writes[0].options?.domain, "opencvhub.netlify.app");
-  assert.equal(cookieStore.writes[1].options?.domain, "opencvhub.netlify.app");
+test("setAuthCookies applies configured cookie domain in production deploy context when app env is missing", () => {
+  withEnv(
+    {
+      NEXT_PUBLIC_APP_ENV: undefined,
+      CONTEXT: "production",
+      NEXT_PUBLIC_COOKIE_DOMAIN: "opencvhub.netlify.app",
+    },
+    () => {
+      const cookieStore = buildCookieStore();
+      setAuthCookies(cookieStore, buildSession());
 
-  process.env.NEXT_PUBLIC_APP_ENV = previousAppEnv;
-  process.env.NEXT_PUBLIC_COOKIE_DOMAIN = previousCookieDomain;
+      assert.equal(cookieStore.writes.length, 2);
+      assert.equal(cookieStore.writes[0].options?.domain, "opencvhub.netlify.app");
+      assert.equal(cookieStore.writes[1].options?.domain, "opencvhub.netlify.app");
+    },
+  );
 });


### PR DESCRIPTION
### Motivation
- Users experienced a login redirect loop in preview environments where sign-in reported success but protected pages immediately redirected back to login.
- Investigation showed cookies were written with a domain scope that the preview host could not read when `NEXT_PUBLIC_APP_ENV` was missing, breaking session recognition.
- The intent is to ensure auth cookies are host-only in non-production deployments so preview hosts can read the session and avoid the redirect loop.

### Description
- Introduced `isProductionCookieScope()` to detect production deploys using `NEXT_PUBLIC_APP_ENV` and fallback deploy context variables (`CONTEXT` / `VERCEL_ENV`).
- Updated `getCookieDomain()` to return a configured domain only when the deployment is explicitly production, otherwise return `undefined` to keep host-only cookies.
- Expanded and refactored `tests/auth-cookies.test.mjs` to cover cases with and without `NEXT_PUBLIC_APP_ENV` for both preview and production deploy contexts using a `withEnv` helper.
- Changes are limited to `app/lib/auth-cookies.ts` and test coverage in `tests/auth-cookies.test.mjs` to avoid wider regressions.

### Testing
- Ran the focused test file with `npm test -- tests/auth-cookies.test.mjs`, and all added tests passed (4/4).
- Ran the full test suite with `npm test`, and the suite passed (36 tests all green).
- Static checks `npm run lint` and `npm run typecheck` were executed and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a9489f4832d8542b34c981ac71a)