### PR TITLE
fix(admin): add account dropdown with role display and home logout

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,4 +1,4 @@
-import SignOutButton from "../components/signout-button";
+import AccountMenu from "../components/account-menu";
 import AdminUsersClient from "./admin-users-client";
 import { requireStaffActor } from "../lib/auth-server";
 import { fetchAllProfilesAsService, fetchAuthUsersAsService } from "../lib/supabase-http";
@@ -52,7 +52,7 @@ export default async function AdminPage() {
             Role: <strong>{actor.role}</strong>. Manage users, roles, activity and account deletion.
           </p>
         </div>
-        <SignOutButton />
+        <AccountMenu email={actor.email} role={actor.role} />
       </header>
       <AdminUsersClient actorRole={actor.role} initialUsers={initialUsers} initialStats={initialStats} />
     </section>

--- a/app/components/account-menu.tsx
+++ b/app/components/account-menu.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import type { AppRole } from "../lib/auth-types";
+
+type Props = {
+  email: string;
+  role: AppRole;
+};
+
+function getInitial(email: string): string {
+  if (!email) {
+    return "U";
+  }
+  return email.trim().charAt(0).toUpperCase() || "U";
+}
+
+export default function AccountMenu({ email, role }: Props) {
+  const [isBusy, setIsBusy] = useState(false);
+
+  async function handleSignOut() {
+    if (isBusy) {
+      return;
+    }
+    setIsBusy(true);
+    await fetch("/api/auth/signout", { method: "POST" });
+    window.location.href = "/";
+  }
+
+  return (
+    <details className="account-menu">
+      <summary className="account-menu__trigger" aria-label="Open account menu">
+        <span className="account-menu__avatar" aria-hidden>
+          {getInitial(email)}
+        </span>
+        <span className="account-menu__identity">
+          <span className="account-menu__email">{email}</span>
+          <span className="account-menu__role">{role}</span>
+        </span>
+      </summary>
+      <div className="account-menu__dropdown" role="menu" aria-label="Account actions">
+        <button type="button" className="account-menu__item" disabled>
+          Profile
+        </button>
+        <button type="button" className="account-menu__item" disabled>
+          Settings
+        </button>
+        <button type="button" className="account-menu__item account-menu__item--danger" onClick={handleSignOut} disabled={isBusy}>
+          {isBusy ? "Signing out..." : "Log out"}
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -496,3 +496,92 @@ a {
     grid-template-columns: 1fr;
   }
 }
+
+.account-menu {
+  position: relative;
+}
+
+.account-menu__trigger {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem 0.35rem 0.35rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.account-menu__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.account-menu__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #5d7cff, #7d65f7);
+}
+
+.account-menu__identity {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.account-menu__email {
+  font-size: 0.85rem;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.account-menu__role {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: capitalize;
+  line-height: 1.2;
+}
+
+.account-menu__dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.45rem);
+  min-width: 170px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.35rem;
+  display: grid;
+  gap: 0.2rem;
+  z-index: 20;
+}
+
+.account-menu__item {
+  text-align: left;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+}
+
+.account-menu__item:disabled {
+  color: var(--muted);
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.account-menu__item--danger {
+  color: #ffb1b1;
+  cursor: pointer;
+}
+
+.account-menu__item--danger:hover:not(:disabled) {
+  background: rgba(180, 30, 30, 0.18);
+}


### PR DESCRIPTION
### Motivation
- Improve admin header UX by showing the signed-in identity and role so staff know which account is active.
- Provide an account menu with the requested actions (Profile, Settings, Log out) while keeping Profile/Settings disabled for now.
- Ensure logout performs server signout and redirects the user to the homepage as requested.

### Description
- Added a new client component `app/components/account-menu.tsx` which renders a round avatar initial, email, role, and a dropdown menu with `Profile` and `Settings` (disabled) and an active `Log out` action that POSTs to `/api/auth/signout` and redirects to `/`.
- Replaced the `SignOutButton` in `app/admin/page.tsx` with the new `AccountMenu` component so the menu appears in the admin header and receives the actor's `email` and `role`.
- Added CSS rules in `app/globals.css` to style the account trigger, avatar, identity lines, dropdown and menu items.
- Preserved existing RBAC checks and did not modify server-side role enforcement; non-staff users remain redirected by existing logic.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run typecheck` and it completed successfully.
- Ran the test suite with `npm test` and all tests passed (34 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91d1e5b30832d9dd539053f0bbeb2)