### PR TITLE
Add AccountMenu component, replace SignOutButton in admin, add styles and Supabase seed script

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,4 +1,4 @@
-import SignOutButton from "../components/signout-button";
+import AccountMenu from "../components/account-menu";
 import AdminUsersClient from "./admin-users-client";
 import { requireStaffActor } from "../lib/auth-server";
 import { fetchAllProfilesAsService, fetchAuthUsersAsService } from "../lib/supabase-http";
@@ -52,7 +52,7 @@ export default async function AdminPage() {
             Role: <strong>{actor.role}</strong>. Manage users, roles, activity and account deletion.
           </p>
         </div>
-        <SignOutButton />
+        <AccountMenu email={actor.email} role={actor.role} />
       </header>
       <AdminUsersClient actorRole={actor.role} initialUsers={initialUsers} initialStats={initialStats} />
     </section>

--- a/app/components/account-menu.tsx
+++ b/app/components/account-menu.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import type { AppRole } from "../lib/auth-types";
+
+type Props = {
+  email: string;
+  role: AppRole;
+};
+
+function getInitial(email: string): string {
+  if (!email) {
+    return "U";
+  }
+  return email.trim().charAt(0).toUpperCase() || "U";
+}
+
+export default function AccountMenu({ email, role }: Props) {
+  const [isBusy, setIsBusy] = useState(false);
+
+  async function handleSignOut() {
+    if (isBusy) {
+      return;
+    }
+    setIsBusy(true);
+    await fetch("/api/auth/signout", { method: "POST" });
+    window.location.href = "/";
+  }
+
+  return (
+    <details className="account-menu">
+      <summary className="account-menu__trigger" aria-label="Open account menu">
+        <span className="account-menu__avatar" aria-hidden>
+          {getInitial(email)}
+        </span>
+        <span className="account-menu__identity">
+          <span className="account-menu__email">{email}</span>
+          <span className="account-menu__role">{role}</span>
+        </span>
+      </summary>
+      <div className="account-menu__dropdown" role="menu" aria-label="Account actions">
+        <button type="button" className="account-menu__item" disabled>
+          Profile
+        </button>
+        <button type="button" className="account-menu__item" disabled>
+          Settings
+        </button>
+        <button type="button" className="account-menu__item account-menu__item--danger" onClick={handleSignOut} disabled={isBusy}>
+          {isBusy ? "Signing out..." : "Log out"}
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -496,3 +496,92 @@ a {
     grid-template-columns: 1fr;
   }
 }
+
+.account-menu {
+  position: relative;
+}
+
+.account-menu__trigger {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem 0.35rem 0.35rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.account-menu__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.account-menu__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #5d7cff, #7d65f7);
+}
+
+.account-menu__identity {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.account-menu__email {
+  font-size: 0.85rem;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.account-menu__role {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: capitalize;
+  line-height: 1.2;
+}
+
+.account-menu__dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.45rem);
+  min-width: 170px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.35rem;
+  display: grid;
+  gap: 0.2rem;
+  z-index: 20;
+}
+
+.account-menu__item {
+  text-align: left;
+  width: 100%;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+}
+
+.account-menu__item:disabled {
+  color: var(--muted);
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.account-menu__item--danger {
+  color: #ffb1b1;
+  cursor: pointer;
+}
+
+.account-menu__item--danger:hover:not(:disabled) {
+  background: rgba(180, 30, 30, 0.18);
+}

--- a/supabase/manual/20260423_seed_staff_and_role_accounts.sql
+++ b/supabase/manual/20260423_seed_staff_and_role_accounts.sql
@@ -1,0 +1,129 @@
+-- Manual SQL script for PROD/TEST Supabase projects.
+-- Purpose:
+-- 1) Ensure required auth emails exist.
+-- 2) Ensure matching public.profiles rows exist.
+-- 3) Assign target RBAC roles.
+--
+-- Role mapping requested by product:
+-- - ADMIN -> 'admin'
+-- - MANAGER -> 'manager'
+-- - RECRUITER -> 'recruiter'
+-- - STANDARD_USER -> 'user'
+
+begin;
+
+create extension if not exists pgcrypto;
+
+do $$
+declare
+  target record;
+  target_user_id uuid;
+  normalized_email text;
+begin
+  for target in
+    select *
+    from (
+      values
+        ('opencvproject+admin@proton.me', 'admin'),
+        ('opencvproject+manager@proton.me', 'manager'),
+        ('opencvproject+recruiter@proton.me', 'recruiter'),
+        ('opencvproject+user@proton.me', 'user')
+    ) as seed(email, app_role)
+  loop
+    normalized_email := lower(trim(target.email));
+
+    select u.id
+    into target_user_id
+    from auth.users u
+    where lower(u.email) = normalized_email
+    limit 1;
+
+    if target_user_id is null then
+      target_user_id := gen_random_uuid();
+
+      insert into auth.users (
+        id,
+        instance_id,
+        aud,
+        role,
+        email,
+        encrypted_password,
+        email_confirmed_at,
+        raw_app_meta_data,
+        raw_user_meta_data,
+        created_at,
+        updated_at,
+        confirmation_token,
+        email_change,
+        email_change_token_new,
+        recovery_token
+      )
+      values (
+        target_user_id,
+        '00000000-0000-0000-0000-000000000000',
+        'authenticated',
+        'authenticated',
+        normalized_email,
+        crypt(gen_random_uuid()::text, gen_salt('bf')),
+        now(),
+        jsonb_build_object('provider', 'email', 'providers', array['email']),
+        jsonb_build_object('full_name', split_part(normalized_email, '@', 1)),
+        now(),
+        now(),
+        '',
+        '',
+        '',
+        ''
+      );
+
+      insert into auth.identities (
+        id,
+        user_id,
+        identity_data,
+        provider,
+        provider_id,
+        created_at,
+        updated_at,
+        last_sign_in_at
+      )
+      values (
+        gen_random_uuid(),
+        target_user_id,
+        jsonb_build_object('sub', target_user_id::text, 'email', normalized_email),
+        'email',
+        normalized_email,
+        now(),
+        now(),
+        now()
+      )
+      on conflict (provider, provider_id) do nothing;
+    end if;
+
+    insert into public.profiles (id, display_name, role, is_active)
+    values (
+      target_user_id,
+      split_part(normalized_email, '@', 1),
+      target.app_role,
+      true
+    )
+    on conflict (id) do update
+      set role = excluded.role,
+          is_active = true,
+          updated_at = now();
+  end loop;
+end
+$$;
+
+commit;
+
+-- Verification helper:
+-- select u.email, p.role, p.is_active
+-- from auth.users u
+-- join public.profiles p on p.id = u.id
+-- where lower(u.email) in (
+--   'opencvproject+admin@proton.me',
+--   'opencvproject+manager@proton.me',
+--   'opencvproject+recruiter@proton.me',
+--   'opencvproject+user@proton.me'
+-- )
+-- order by u.email;


### PR DESCRIPTION
### Motivation

- Replace the simple sign-out button with a compact account menu in the admin header to show the current user's email and role and provide a polished sign-out flow.
- Add styling for the new account menu to match existing UI patterns and ensure responsive behavior.
- Provide a manual Supabase SQL script to seed required staff and role accounts for PROD/TEST environments so RBAC roles and profiles exist.

### Description

- Added a client component `app/components/account-menu.tsx` that renders an account menu with avatar initial, email, role and a sign-out action that posts to `/api/auth/signout` and redirects to `/`.
- Replaced the previous `SignOutButton` import with `AccountMenu` in `app/admin/page.tsx` and pass `email` and `role` from the actor to the component.
- Extended `app/globals.css` with `.account-menu*` styles to layout the trigger, avatar, dropdown, and menu items including a danger style for log out.
- Added `supabase/manual/20260423_seed_staff_and_role_accounts.sql`, a manual SQL script that creates auth users and matching `public.profiles` rows for admin/manager/recruiter/user emails and assigns the requested application roles.

### Testing

- Ran the project build and type-check (`npm run build` / TypeScript checks) which completed successfully.
- Executed the existing automated test suite (`npm test`) which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91d1e5b30832d9dd539053f0bbeb2)