### PR TITLE
fix: update header auth and admin menu visibility

### DIFF
--- a/app/components/account-menu.tsx
+++ b/app/components/account-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import type { AppRole } from "../lib/auth-types";
 
@@ -39,6 +40,11 @@ export default function AccountMenu({ email, role }: Props) {
         </span>
       </summary>
       <div className="account-menu__dropdown" role="menu" aria-label="Account actions">
+        {role === "admin" && (
+          <Link href="/admin" className="account-menu__item" role="menuitem">
+            User management
+          </Link>
+        )}
         <button type="button" className="account-menu__item" disabled>
           Profile
         </button>

--- a/app/components/header-account-menu.tsx
+++ b/app/components/header-account-menu.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+type Props = {
+  actor: ReactNode;
+};
+
+export default function HeaderAccountMenu({ actor }: Props) {
+  const pathname = usePathname();
+
+  if (!actor || pathname === "/") {
+    return null;
+  }
+
+  return actor;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 ﻿import type { Metadata } from "next";
 import Link from "next/link";
 import AccountMenu from "./components/account-menu";
+import HeaderAccountMenu from "./components/header-account-menu";
 import { getCurrentActor } from "./lib/auth-server";
 import "./globals.css";
 
@@ -22,13 +23,12 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
             </Link>
             <div className="app-header__controls">
               <nav className="app-nav" aria-label="Primary">
-                <Link href="/login">Login</Link>
+                {!actor && <Link href="/login">Login</Link>}
                 <Link href="/dashboard">Dashboard</Link>
                 <Link href="/master-resume">Editor</Link>
-                <Link href="/admin">Admin</Link>
                 <Link href="/resume">Sample CV</Link>
               </nav>
-              {actor && <AccountMenu email={actor.email} role={actor.role} />}
+              <HeaderAccountMenu actor={actor ? <AccountMenu email={actor.email} role={actor.role} /> : null} />
             </div>
           </div>
         </header>


### PR DESCRIPTION
### Motivation
- Simplify and secure the top navigation by moving admin controls into the authenticated account menu and hiding auth links when not relevant.
- Ensure the `Admin` area is only discoverable via the account dropdown for authorized users and that the header remains minimal on the landing page (`/`).

### Description
- Update `app/layout.tsx` to only render the `Login` link when there is no current actor and to remove the top-level `Admin` link, replacing the account injection with a `HeaderAccountMenu` wrapper component.
- Add `app/components/header-account-menu.tsx` to hide the account menu entirely on the landing page (`/`) while still showing it on other routes when a session exists.
- Modify `app/components/account-menu.tsx` to include an admin-only `User management` link (`/admin`) shown only when `role === "admin"` and maintain existing sign-out/profile entries.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm test` and the suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7b648d04832d92d44dffc15f102c)