### PR TITLE
refactor: improve homepage UX and simplify auth access client state handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -602,3 +602,102 @@ a {
 .account-menu__item--danger:hover:not(:disabled) {
   background: rgba(180, 30, 30, 0.18);
 }
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+}
+
+.button,
+.tab,
+input,
+select,
+textarea,
+a {
+  transition: all 160ms ease;
+}
+
+.button:focus-visible,
+.tab:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible,
+.account-menu__trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.hero-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.03));
+}
+
+.eyebrow {
+  margin: 0;
+  color: #b6c3e8;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.stack--lg {
+  gap: 1.35rem;
+}
+
+.quick-actions {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.8rem;
+}
+
+.quick-actions__item {
+  display: grid;
+  gap: 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.8rem;
+  background: rgba(16, 23, 42, 0.65);
+}
+
+.quick-actions__item:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.quick-actions__label {
+  font-weight: 600;
+}
+
+.quick-actions__helper {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.feature-card p {
+  margin-bottom: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/app/login/account-access-client.tsx
+++ b/app/login/account-access-client.tsx
@@ -5,7 +5,23 @@ import { postJson } from "../lib/client-http";
 
 type TabId = "signin" | "signup" | "reset" | "new-password";
 
-const DEFAULT_STATUS = "";
+type Props = {
+  reason: string;
+  verified: string;
+};
+
+type StatusKind = "idle" | "ok" | "error";
+
+type AuthTab = {
+  id: Exclude<TabId, "new-password">;
+  label: string;
+};
+
+const AUTH_TABS: AuthTab[] = [
+  { id: "signin", label: "Sign in" },
+  { id: "signup", label: "Sign up" },
+  { id: "reset", label: "Reset password" },
+];
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
@@ -15,15 +31,26 @@ function parseHashParams(hash: string): URLSearchParams {
   return new URLSearchParams(hash.replace(/^#/, ""));
 }
 
-type Props = {
-  reason: string;
-  verified: string;
-};
+function getContextualMessage(reason: string, verified: string): string {
+  if (verified === "1") {
+    return "Email verification completed. You can sign in now.";
+  }
+  if (reason === "inactive") {
+    return "Your account is inactive. Contact support or an administrator.";
+  }
+  if (reason === "unverified") {
+    return "Email verification must be completed before access is granted.";
+  }
+  if (reason === "session") {
+    return "Session could not be restored. Please sign in again.";
+  }
+  return "";
+}
 
 export default function AccountAccessClient({ reason, verified }: Props) {
   const [activeTab, setActiveTab] = useState<TabId>("signin");
-  const [status, setStatus] = useState(DEFAULT_STATUS);
-  const [error, setError] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [statusKind, setStatusKind] = useState<StatusKind>("idle");
   const [isBusy, setIsBusy] = useState(false);
   const [pendingVerificationEmail, setPendingVerificationEmail] = useState("");
 
@@ -35,64 +62,56 @@ export default function AccountAccessClient({ reason, verified }: Props) {
   const [newPassword, setNewPassword] = useState("");
   const [recoveryToken, setRecoveryToken] = useState("");
 
-  const contextualMessage = useMemo(() => {
-    if (verified === "1") {
-      return "Email verification completed. You can sign in now.";
-    }
-    if (reason === "inactive") {
-      return "Your account is inactive. Contact support or an administrator.";
-    }
-    if (reason === "unverified") {
-      return "Email verification must be completed before access is granted.";
-    }
-    if (reason === "session") {
-      return "Session could not be restored. Please sign in again.";
-    }
-    return "";
-  }, [reason, verified]);
+  const contextualMessage = useMemo(() => getContextualMessage(reason, verified), [reason, verified]);
+
+  function setBusyStatus(message: string) {
+    setStatusMessage(message);
+    setStatusKind("ok");
+    setIsBusy(true);
+  }
+
+  function setErrorStatus(message: string) {
+    setStatusMessage(message);
+    setStatusKind("error");
+  }
+
+  function setOkStatus(message: string) {
+    setStatusMessage(message);
+    setStatusKind("ok");
+  }
 
   useEffect(() => {
     const hashParams = parseHashParams(window.location.hash);
     if (hashParams.get("type") === "recovery" && hashParams.get("access_token")) {
       setRecoveryToken(hashParams.get("access_token")!);
       setActiveTab("new-password");
-      setStatus("Set your new password below.");
-      setError(false);
-      // Clean hash from URL without reload
+      setOkStatus("Set your new password below.");
       window.history.replaceState(null, "", window.location.pathname + window.location.search);
     }
   }, []);
 
   async function handleSignIn(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setIsBusy(true);
-    setStatus("Signing in...");
-    setError(false);
+    setBusyStatus("Signing in...");
 
     const email = normalizeEmail(signinEmail);
     let shouldRedirect = false;
 
     try {
-      const payload = await postJson("/api/auth/signin", {
-        email,
-        password: signinPassword,
-      });
+      const payload = await postJson("/api/auth/signin", { email, password: signinPassword });
 
       if (payload.error) {
-        setStatus(payload.error);
-        setError(true);
+        setErrorStatus(payload.error);
         setPendingVerificationEmail(email);
         return;
       }
 
       setPendingVerificationEmail("");
-      setStatus("Signed in. Redirecting...");
-      setError(false);
+      setOkStatus("Signed in. Redirecting...");
       shouldRedirect = true;
       window.location.href = "/dashboard";
     } catch {
-      setStatus("Unexpected sign-in error. Try again.");
-      setError(true);
+      setErrorStatus("Unexpected sign-in error. Try again.");
     } finally {
       if (!shouldRedirect) {
         setIsBusy(false);
@@ -102,32 +121,24 @@ export default function AccountAccessClient({ reason, verified }: Props) {
 
   async function handleSignUp(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setIsBusy(true);
-    setStatus("Creating account...");
-    setError(false);
+    setBusyStatus("Creating account...");
 
     const email = normalizeEmail(signupEmail);
 
     try {
-      const payload = await postJson("/api/auth/signup", {
-        email,
-        password: signupPassword,
-      });
+      const payload = await postJson("/api/auth/signup", { email, password: signupPassword });
 
       if (payload.error) {
-        setStatus(payload.error);
-        setError(true);
+        setErrorStatus(payload.error);
         return;
       }
 
-      setStatus(payload.message || "Account created. Verify your email before sign in.");
+      setOkStatus(payload.message || "Account created. Verify your email before sign in.");
       setPendingVerificationEmail(email);
-      setError(false);
       setActiveTab("signin");
       setSigninEmail(email);
     } catch {
-      setStatus("Unexpected sign-up error. Try again.");
-      setError(true);
+      setErrorStatus("Unexpected sign-up error. Try again.");
     } finally {
       setIsBusy(false);
     }
@@ -135,28 +146,21 @@ export default function AccountAccessClient({ reason, verified }: Props) {
 
   async function handleResetPassword(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setIsBusy(true);
-    setStatus("Sending reset link...");
-    setError(false);
+    setBusyStatus("Sending reset link...");
 
     const email = normalizeEmail(resetEmail);
 
     try {
-      const payload = await postJson("/api/auth/reset-password", {
-        email,
-      });
+      const payload = await postJson("/api/auth/reset-password", { email });
 
       if (payload.error) {
-        setStatus(payload.error);
-        setError(true);
+        setErrorStatus(payload.error);
         return;
       }
 
-      setStatus(payload.message || "Password reset email sent.");
-      setError(false);
+      setOkStatus(payload.message || "Password reset email sent.");
     } catch {
-      setStatus("Unexpected password reset error. Try again.");
-      setError(true);
+      setErrorStatus("Unexpected password reset error. Try again.");
     } finally {
       setIsBusy(false);
     }
@@ -165,28 +169,22 @@ export default function AccountAccessClient({ reason, verified }: Props) {
   async function handleResendVerification() {
     const email = normalizeEmail(pendingVerificationEmail || signinEmail);
     if (!email) {
-      setStatus("Provide email in sign-in form first.");
-      setError(true);
+      setErrorStatus("Provide email in sign-in form first.");
       return;
     }
 
-    setIsBusy(true);
-    setStatus("Sending verification email...");
-    setError(false);
+    setBusyStatus("Sending verification email...");
 
     try {
       const payload = await postJson("/api/auth/resend-verification", { email });
       if (payload.error) {
-        setStatus(payload.error);
-        setError(true);
+        setErrorStatus(payload.error);
         return;
       }
 
-      setStatus(payload.message || "Verification email sent.");
-      setError(false);
+      setOkStatus(payload.message || "Verification email sent.");
     } catch {
-      setStatus("Unexpected verification error. Try again.");
-      setError(true);
+      setErrorStatus("Unexpected verification error. Try again.");
     } finally {
       setIsBusy(false);
     }
@@ -194,9 +192,7 @@ export default function AccountAccessClient({ reason, verified }: Props) {
 
   async function handleUpdatePassword(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setIsBusy(true);
-    setStatus("Updating password...");
-    setError(false);
+    setBusyStatus("Updating password...");
 
     try {
       const payload = await postJson("/api/auth/update-password", {
@@ -205,60 +201,58 @@ export default function AccountAccessClient({ reason, verified }: Props) {
       });
 
       if (payload.error) {
-        setStatus(payload.error);
-        setError(true);
+        setErrorStatus(payload.error);
         return;
       }
 
-      setStatus(payload.message || "Password updated. You can sign in now.");
-      setError(false);
+      setOkStatus(payload.message || "Password updated. You can sign in now.");
       setRecoveryToken("");
       setNewPassword("");
       setActiveTab("signin");
     } catch {
-      setStatus("Unexpected error. Try again.");
-      setError(true);
+      setErrorStatus("Unexpected error. Try again.");
     } finally {
       setIsBusy(false);
     }
   }
+
+  const statusToRender = statusMessage || contextualMessage;
 
   return (
     <section className="card auth-card">
       <h1>Account access</h1>
       <p className="card-lead">Phase C provides sign up, sign in, password reset, email verification and RBAC.</p>
 
-      {(contextualMessage || status) && (
-        <p className={`status ${error ? "status--error" : "status--ok"}`}>{status || contextualMessage}</p>
+      {statusToRender && (
+        <p
+          className={`status ${statusKind === "error" ? "status--error" : "status--ok"}`}
+          role="status"
+          aria-live="polite"
+        >
+          {statusToRender}
+        </p>
       )}
 
       <div className="tabs" role="tablist" aria-label="Auth actions">
-        <button
-          type="button"
-          className={`tab ${activeTab === "signin" ? "is-active" : ""}`}
-          onClick={() => setActiveTab("signin")}
-        >
-          Sign in
-        </button>
-        <button
-          type="button"
-          className={`tab ${activeTab === "signup" ? "is-active" : ""}`}
-          onClick={() => setActiveTab("signup")}
-        >
-          Sign up
-        </button>
-        <button
-          type="button"
-          className={`tab ${activeTab === "reset" ? "is-active" : ""}`}
-          onClick={() => setActiveTab("reset")}
-        >
-          Reset password
-        </button>
+        {AUTH_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={`tab ${activeTab === tab.id ? "is-active" : ""}`}
+            onClick={() => setActiveTab(tab.id)}
+            aria-selected={activeTab === tab.id}
+            role="tab"
+          >
+            {tab.label}
+          </button>
+        ))}
         {recoveryToken && (
           <button
             type="button"
             className={`tab ${activeTab === "new-password" ? "is-active" : ""}`}
             onClick={() => setActiveTab("new-password")}
+            aria-selected={activeTab === "new-password"}
+            role="tab"
           >
             New password
           </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,55 @@
+import Link from "next/link";
+
+const PLATFORM_PILLARS = [
+  {
+    title: "Bezpieczne logowanie i RBAC",
+    description: "Rejestracja, weryfikacja email, reset hasła oraz role admin/manager/user/recruiter.",
+  },
+  {
+    title: "Nowy edytor CV",
+    description: "Iteracyjnie rozwijany edytor oparty o Next.js z live preview i kontrolą publikacji.",
+  },
+  {
+    title: "Zgodność wsteczna",
+    description: "Utrzymane legacy ścieżki oraz migracja bez ryzyka big-bang rewrite.",
+  },
+] as const;
+
+const QUICK_ACTIONS = [
+  { href: "/login", label: "Zaloguj się", helper: "Dostęp do konta i odzyskiwanie hasła" },
+  { href: "/dashboard", label: "Przejdź do dashboardu", helper: "Podgląd stanu konta i ról" },
+  { href: "/master-resume", label: "Otwórz edytor", helper: "Tworzenie i publikacja CV" },
+] as const;
+
 export default function HomePage() {
   return (
-    <section className="card">
-      <h1>OpenCVHub Rebuild</h1>
-      <p>
-        Platform foundation and auth core are active. The app runs on Next.js with TypeScript, CI gates, and
-        Supabase-based authentication with RBAC.
-      </p>
-      <ul>
-        <li>Next.js App Router scaffold</li>
-        <li>Sign in, sign up, reset password, and verification workflows</li>
-        <li>Admin panel for role assignment, account status, and deletion constraints</li>
-        <li>Legacy URL compatibility redirects</li>
-      </ul>
+    <section className="stack stack--lg">
+      <article className="card hero-card">
+        <p className="eyebrow">OpenCVHub · Next.js Rebuild</p>
+        <h1>Nowoczesna, czytelna platforma do zarządzania CV</h1>
+        <p className="card-lead">
+          Fundament aplikacji działa produkcyjnie. Priorytetem jest UX oparty o prostą nawigację, szybki onboarding
+          i przewidywalne zachowanie interfejsu.
+        </p>
+
+        <div className="quick-actions" aria-label="Szybkie akcje">
+          {QUICK_ACTIONS.map((action) => (
+            <Link key={action.href} href={action.href} className="quick-actions__item">
+              <span className="quick-actions__label">{action.label}</span>
+              <span className="quick-actions__helper">{action.helper}</span>
+            </Link>
+          ))}
+        </div>
+      </article>
+
+      <section className="feature-grid" aria-label="Filary platformy">
+        {PLATFORM_PILLARS.map((pillar) => (
+          <article key={pillar.title} className="card feature-card">
+            <h2>{pillar.title}</h2>
+            <p>{pillar.description}</p>
+          </article>
+        ))}
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve first-run UX and information hierarchy on the landing page while making the auth client code clearer, more accessible, and easier to maintain.
- Apply small, reversible UI refinements and accessibility improvements inside `app/` without changing API or database contracts.

### Description
- Redesigned the homepage in `app/page.tsx` to include a hero card, quick actions grid, and feature pillars for clearer onboarding and navigation.
- Refactored `app/login/account-access-client.tsx` to centralize status handling (`setBusyStatus`, `setOkStatus`, `setErrorStatus`), introduce a typed `AUTH_TABS` config, extract contextual messaging, and add ARIA semantics for status and tabs.
- Extended `app/globals.css` with modern UX helpers including a sticky header, `focus-visible` outlines, reduced-motion support, micro-interactions, and styles for the new hero/quick-actions/feature cards.
- No API, DB, or public contract changes were introduced; copy for the homepage was adjusted to Polish for UX direction only.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm test` and the full test suite passed (36 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7fc6ee50832dbc8c727e5bc523fa)