### PR TITLE
fix: update header navigation and guest login trigger

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,40 @@ a {
   flex-wrap: wrap;
 }
 
+
+.login-menu-trigger {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem 0.35rem 0.35rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.login-menu-trigger:hover {
+  border-color: var(--accent);
+}
+
+.login-menu-trigger__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #ffffff;
+  background: linear-gradient(135deg, #5d7cff, #7d65f7);
+}
+
+.login-menu-trigger__label {
+  font-size: 0.85rem;
+  color: var(--text);
+  line-height: 1.2;
+}
+
 .app-main {
   padding: 2rem 0 3rem;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-﻿import type { Metadata } from "next";
+import type { Metadata } from "next";
 import Link from "next/link";
 import AccountMenu from "./components/account-menu";
 import HeaderAccountMenu from "./components/header-account-menu";
@@ -23,12 +23,20 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
             </Link>
             <div className="app-header__controls">
               <nav className="app-nav" aria-label="Primary">
-                {!actor && <Link href="/login">Login</Link>}
-                <Link href="/dashboard">Dashboard</Link>
-                <Link href="/master-resume">Editor</Link>
+                {actor && <Link href="/dashboard">Dashboard</Link>}
+                {actor && <Link href="/master-resume">Editor</Link>}
                 <Link href="/resume">Sample CV</Link>
               </nav>
-              <HeaderAccountMenu actor={actor ? <AccountMenu email={actor.email} role={actor.role} /> : null} />
+              {actor ? (
+                <HeaderAccountMenu actor={<AccountMenu email={actor.email} role={actor.role} />} />
+              ) : (
+                <Link className="login-menu-trigger" href="/login" aria-label="Go to login">
+                  <span className="login-menu-trigger__avatar" aria-hidden>
+                    L
+                  </span>
+                  <span className="login-menu-trigger__label">Login</span>
+                </Link>
+              )}
             </div>
           </div>
         </header>


### PR DESCRIPTION
### Motivation
- Remove links that are protected for signed-out users and fix the alignment/look of the login trigger so a guest sees only "Sample CV" plus a right-aligned login button styled like the account menu.

### Description
- Changed `app/layout.tsx` so `Dashboard` and `Editor` only render when an `actor` exists, and so `Sample CV` is always visible.
- For signed-out users, replaced the plain `Login` link with a new right-aligned pill-shaped trigger containing an avatar and label (`.login-menu-trigger`).
- Added trigger styling to `app/globals.css` (`.login-menu-trigger`, `.login-menu-trigger__avatar`, `.login-menu-trigger__label`) to match the existing `account-menu` look.
- The change is UI/markup/styling only and doesn't modify auth logic or the API.

### Testing
- Ran `npm run lint` — passed.
- Ran `npm run typecheck` — passed.
- Ran `npm test` — all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8079b490832d9a31148b011dab01)
