### PR TITLE
feat: move profile metadata from Dashboard into Profile modal in account menu

### DIFF
--- a/app/components/account-menu.tsx
+++ b/app/components/account-menu.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { AppRole } from "../lib/auth-types";
 
 type Props = {
   email: string;
   role: AppRole;
+  isActive: boolean;
+  emailConfirmed: boolean;
 };
 
 function getInitial(email: string): string {
@@ -16,8 +18,10 @@ function getInitial(email: string): string {
   return email.trim().charAt(0).toUpperCase() || "U";
 }
 
-export default function AccountMenu({ email, role }: Props) {
+export default function AccountMenu({ email, role, isActive, emailConfirmed }: Props) {
   const [isBusy, setIsBusy] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const menuRef = useRef<HTMLDetailsElement>(null);
 
   async function handleSignOut() {
     if (isBusy) {
@@ -28,8 +32,16 @@ export default function AccountMenu({ email, role }: Props) {
     window.location.href = "/";
   }
 
+  function openProfileModal() {
+    setIsProfileOpen(true);
+    if (menuRef.current) {
+      menuRef.current.open = false;
+    }
+  }
+
   return (
-    <details className="account-menu">
+    <>
+    <details className="account-menu" ref={menuRef}>
       <summary className="account-menu__trigger" aria-label="Open account menu">
         <span className="account-menu__avatar" aria-hidden>
           {getInitial(email)}
@@ -40,14 +52,14 @@ export default function AccountMenu({ email, role }: Props) {
         </span>
       </summary>
       <div className="account-menu__dropdown" role="menu" aria-label="Account actions">
+        <button type="button" className="account-menu__item" onClick={openProfileModal}>
+          Profile
+        </button>
         {role === "admin" && (
           <Link href="/admin" className="account-menu__item" role="menuitem">
             User management
           </Link>
         )}
-        <button type="button" className="account-menu__item" disabled>
-          Profile
-        </button>
         <button type="button" className="account-menu__item" disabled>
           Settings
         </button>
@@ -56,5 +68,32 @@ export default function AccountMenu({ email, role }: Props) {
         </button>
       </div>
     </details>
+      {isProfileOpen && (
+        <dialog className="profile-modal" open aria-labelledby="profile-modal-title">
+          <div className="profile-modal__content">
+            <div className="profile-modal__header">
+              <h2 id="profile-modal-title">Profile</h2>
+              <button type="button" className="button button--ghost button--small" onClick={() => setIsProfileOpen(false)}>
+                Close
+              </button>
+            </div>
+            <div className="meta-grid">
+              <p>
+                <span className="meta-label">Role</span>
+                <span className="meta-value">{role}</span>
+              </p>
+              <p>
+                <span className="meta-label">Status</span>
+                <span className="meta-value">{isActive ? "active" : "inactive"}</span>
+              </p>
+              <p>
+                <span className="meta-label">Email verification</span>
+                <span className="meta-value">{emailConfirmed ? "verified" : "pending"}</span>
+              </p>
+            </div>
+          </div>
+        </dialog>
+      )}
+    </>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import SignOutButton from "../components/signout-button";
 import { requireAuthenticatedActor } from "../lib/auth-server";
-import { canAccessAdminArea } from "../lib/rbac";
 
 export const dynamic = "force-dynamic";
 
@@ -17,23 +15,7 @@ export default async function DashboardPage() {
             Logged in as <strong>{actor.displayName}</strong> ({actor.email}).
           </p>
         </div>
-        <SignOutButton />
       </header>
-
-      <div className="meta-grid">
-        <p>
-          <span className="meta-label">Role</span>
-          <span className="meta-value">{actor.role}</span>
-        </p>
-        <p>
-          <span className="meta-label">Status</span>
-          <span className="meta-value">{actor.isActive ? "active" : "inactive"}</span>
-        </p>
-        <p>
-          <span className="meta-label">Email verification</span>
-          <span className="meta-value">{actor.emailConfirmed ? "verified" : "pending"}</span>
-        </p>
-      </div>
 
       <div className="actions-row">
         <Link className="button button--primary" href="/master-resume">
@@ -42,11 +24,6 @@ export default async function DashboardPage() {
         <Link className="button button--ghost" href="/resume">
           View sample resume
         </Link>
-        {canAccessAdminArea(actor.role) && (
-          <Link className="button button--ghost" href="/admin">
-            Open admin panel
-          </Link>
-        )}
       </div>
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -602,3 +602,33 @@ a {
 .account-menu__item--danger:hover:not(:disabled) {
   background: rgba(180, 30, 30, 0.18);
 }
+
+.profile-modal {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+  color: var(--text);
+  width: min(560px, calc(100% - 2rem));
+  padding: 0;
+}
+
+.profile-modal::backdrop {
+  background: rgba(3, 8, 20, 0.75);
+}
+
+.profile-modal__content {
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-modal__header h2 {
+  margin: 0;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,18 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
                 <Link href="/master-resume">Editor</Link>
                 <Link href="/resume">Sample CV</Link>
               </nav>
-              <HeaderAccountMenu actor={actor ? <AccountMenu email={actor.email} role={actor.role} /> : null} />
+              <HeaderAccountMenu
+                actor={
+                  actor ? (
+                    <AccountMenu
+                      email={actor.email}
+                      role={actor.role}
+                      isActive={actor.isActive}
+                      emailConfirmed={actor.emailConfirmed}
+                    />
+                  ) : null
+                }
+              />
             </div>
           </div>
         </header>


### PR DESCRIPTION
### Motivation
- Centralize account information by moving `Role`, `Status` and `Email verification` out of the Dashboard into the user menu so `Profile` becomes the primary access point for account details.
- Remove duplicate controls from the Dashboard (sign out and admin panel button) to keep account actions in the account menu dropdown.

### Description
- Update `app/layout.tsx` to pass `isActive` and `emailConfirmed` to `AccountMenu` so the menu can render the profile modal content. 
- Replace the disabled `Profile` item with an actionable button in `app/components/account-menu.tsx` that opens a `<dialog>` modal showing `Role`, `Status` and `Email verification`, and close behavior that collapses the dropdown. 
- Remove profile metadata and the sign-out/admin panel buttons from `app/dashboard/page.tsx` to avoid duplication. 
- Add modal styles in `app/globals.css` to support the new `profile-modal` dialog and backdrop.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm test` and all tests passed (`36` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8180c968832db9ec8fafffa4d131)