### PR TITLE
fix(tests): update script paths for moved public directory

### DIFF
--- a/tests/admin-login.test.js
+++ b/tests/admin-login.test.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 const fs = require('node:fs');
 const { JSDOM } = require('jsdom');
 
-const mainScript = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'main.js'), 'utf8');
+const mainScript = fs.readFileSync(path.join(__dirname, '..', 'public', 'scripts', 'main.js'), 'utf8');
 
 const DISABLED_MESSAGE = 'Editor login disabled. Configure the ADMIN_PASSWORD environment variable.';
 const DEFAULT_ERROR_MESSAGE = 'Incorrect password. Try again.';

--- a/tests/phase-b-yaml-data-layer.test.js
+++ b/tests/phase-b-yaml-data-layer.test.js
@@ -9,14 +9,14 @@ const {
   validateResumeDocumentShape,
   validateResumeYamlContent,
   serializeResumeDocument,
-} = require("../scripts/phase-b/resume-yaml-contract");
+} = require("../public/scripts/phase-b/resume-yaml-contract");
 
 const {
   buildMigrationPlan,
   buildDryRunReport,
   generateSqlBackfill,
   parseCliArgs,
-} = require("../scripts/phase-b/legacy-data-migrator");
+} = require("../public/scripts/phase-b/legacy-data-migrator");
 
 test("empty resume template is schema-valid", () => {
   const template = createEmptyResumeDocument("Ariana Holt");


### PR DESCRIPTION
Fixes CI failing tests caused by recent restructuring where scripts and data were moved to the \public\ directory. The test files were still referencing the old paths.