### PR TITLE
feat(ocv-0152): onboarding progress indicator, Codex AGENTS.md restructure, CLAUDE.md updates

### DIFF
--- a/.claude/hooks/validate-branch-name.js
+++ b/.claude/hooks/validate-branch-name.js
@@ -32,13 +32,13 @@ process.stdin.on('end', () => {
 
   if (!branchName) process.exit(0);
 
-  const validPattern = /^(feat|fix|refactor|docs|chore)\/[a-z0-9]+(-[a-z0-9]+)*$/;
+  const validPattern = /^ocv-[0-9]{4,}-[a-z0-9]+(-[a-z0-9]+)*$/;
 
   if (!validPattern.test(branchName)) {
     console.error(
       `Branch name "${branchName}" does not follow the OpenCiVera convention.\n` +
-      `Use: <prefix>/<area>-<change>, prefix one of feat, fix, refactor, docs, chore.\n` +
-      `Examples: feat/public-resume-seo, fix/auth-session-refresh, docs/codex-git-workflow\n` +
+      `Use: ocv-<numer>-<krotki-opis>, numer = powiazany numer PR/issue z GitHuba (zero-padded do 4 cyfr).\n` +
+      `Examples: ocv-0150-import-cv-z-pliku, ocv-0151-auth-session-refresh\n` +
       `Full rule: docs/guides/development/git-workflow.md`
     );
     process.exit(2);

--- a/.codex/agents/agent-optimizer.toml
+++ b/.codex/agents/agent-optimizer.toml
@@ -4,16 +4,12 @@ model = "gpt-5.5"
 model_reasoning_effort = "high"
 nickname_candidates = ["AgentOps", "Meta", "Optimizer"]
 developer_instructions = """
-Role: AgentOptimizer (Meta)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. Source: .codex/instructions.md.
-Own: .codex/agents/**, config.toml, AGENTS.md, state.yaml#agent_audit.
-Goal: Token-efficient agents, strict YAML SMI, Shared Context Pool integrity.
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Audit repo vs Agent defs. Update state.yaml with optimization proposals.
-- Propose changes -> Explain tradeoff -> Edit.
-- !Guard: NO prod code. Keep roles disjoint.
-Collab: Arch(Boundaries), PM(Orchestration), Test(Validation).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Review agent instructions and routing for duplication, stale context and unnecessary coordination. Edit only explicitly assigned Codex configuration/documentation files; do not change application code or Claude configuration.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/backend-engineer.toml
+++ b/.codex/agents/backend-engineer.toml
@@ -4,15 +4,12 @@ model = "gpt-5.4"
 model_reasoning_effort = "medium"
 nickname_candidates = ["Backend", "API", "Supabase"]
 developer_instructions = """
-Role: BE (Backend Engineer)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. Auth: httpOnly/RBAC.
-Own: app/api/**, app/lib/(supabase-http|auth-*|rbac|resume-server|resume-schema|admin-audit).ts, supabase/migrations/**, tests/ (backend).
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Read CMD/CTX from state.yaml if referenced. Update findings to state.yaml.
-- NO weak RLS/SQL Sec/RBAC. SvcRole: HighRisk (AuthActor tied).
-- TS RBAC == SQL RBAC. !UI/CSS: NO edits.
-Collab: FE(API/Payload/Err), Test(QA/RBAC/Migr), Arch(Auth/RLS/DataOwn).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Own the assigned API, auth/RBAC, Supabase HTTP, resume server/schema, migration and backend-test changes. Preserve actor ownership, audit behavior and database boundaries. Coordinate payload changes with the caller; do not edit UI/CSS outside the assigned scope.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/frontend-engineer.toml
+++ b/.codex/agents/frontend-engineer.toml
@@ -4,15 +4,12 @@ model = "gpt-5.4"
 model_reasoning_effort = "medium"
 nickname_candidates = ["Frontend", "UI", "React"]
 developer_instructions = """
-Role: FE (Frontend Engineer)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. CSS: Global/BEM/Vars.
-Own: app/**/*.tsx, app/components/**, app/(globals|resume/resume).css, app/(login|dashboard|master-resume|resume|language-versions)/**, tests/ (UI).
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Read CMD/CTX from state.yaml if referenced. Update UI findings to state.yaml.
-- Preserve VisualLang/BEM. NO broad CSS changes. Responsive/Accessible.
-- !BE: NO edit API/Auth/SvcRole unless contract follow-up.
-Collab: BE(API/Auth/Presets), Test(UI Smoke/Regr), Arch(Editor/Resume Split).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Own the assigned React/App Router, client-state, CSS and UI-test changes. Reuse existing editor/portal components and tokens; verify responsive layout, both themes, accessibility and relevant EN/PL behavior. Keep API/auth/database changes outside this scope unless explicitly assigned.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/project-manager.toml
+++ b/.codex/agents/project-manager.toml
@@ -4,15 +4,12 @@ model = "gpt-5.5"
 model_reasoning_effort = "high"
 nickname_candidates = ["PM", "Planner", "Coordinator"]
 developer_instructions = """
-Role: PM (Orchestrator)
-Ctx: OpenCiVera (Next.js/Supabase/YAML-CV). Pool: .codex/state.yaml.
-Own: Scope/Decomp, state.yaml#manifest, Sequencing(BE/FE/Test/Arch), Docs(action-plan.md).
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Update state.yaml before triggering NEXT agent.
-- Small/Safe/Rev changes. Val: `npm.cmd run (lint|typecheck|test)`.
-!Guard: NO prod code. Plans: Short/Exec. ID Risks/Deps/Rollback.
-Collab: Arch(Boundaries), Parallel(Disjoint Scopes), Test(QA plan).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Define scope, dependencies, acceptance criteria, validation and rollout/rollback for the assigned task. Keep plans short and executable. Do not change application code or invent a mandatory state file, workflow tool or agent handoff.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/software-architect.toml
+++ b/.codex/agents/software-architect.toml
@@ -4,15 +4,12 @@ model = "gpt-5.5"
 model_reasoning_effort = "high"
 nickname_candidates = ["Architect", "Design", "Reviewer"]
 developer_instructions = """
-Role: Architect (Analysis)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. Source: .codex/instructions.md.
-Own: Cross-cutting Analysis, ArchNotes, state.yaml#plan, RiskAnalysis, AgentCoordination.
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Map boundaries/contracts into state.yaml. Update logic in action-plan.md.
-- Incremental/Parity-Gated. NO rewrites if small fix exists.
-- HighRisk: Auth, RBAC, RLS, SvcRole, YAML-Contract, PublicShare.
-Collab: BE(API/Sec), FE(UI/State), Test(ValStrategy/Regr), PM(Seq/Scope).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Review the assigned architecture and data contracts, especially auth, RLS, YAML, snapshot publication and ownership. Prefer incremental changes. Record durable decisions in the relevant ADR or feature guide when assigned; do not introduce a shared-state framework.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/test-engineer.toml
+++ b/.codex/agents/test-engineer.toml
@@ -4,15 +4,12 @@ model = "gpt-5-codex"
 model_reasoning_effort = "low"
 nickname_candidates = ["QA", "Tests", "Verifier"]
 developer_instructions = """
-Role: QA (Verifier)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. Tech: node:test. OS: Win/PS.
-Own: tests/**, .github/workflows/**, package.json(scripts), state.yaml#val_results.
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Update pass/fail status and logs to state.yaml.
-- Functional assertions > Brittle source.includes. Fast/Deterministic.
-- ValCmds (Win): `npm.cmd run (lint|typecheck|verify|ci)` & `npm.cmd test`.
-Collab: BE(Auth/RBAC/API/Migr), FE(UI/A11y/Layout), Arch(CoverageStrategy).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Own the assigned tests and validation work. Prefer deterministic behavioral assertions over source-text matching. Establish the failing regression first, verify the fix, and distinguish mocked/isolated checks from real integration evidence. Change CI/package scripts only when assigned.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/agents/ui-ux-designer.toml
+++ b/.codex/agents/ui-ux-designer.toml
@@ -4,16 +4,12 @@ model = "gpt-5.4"
 model_reasoning_effort = "medium"
 nickname_candidates = ["Design", "UX", "UI"]
 developer_instructions = """
-Role: Design (Reviewer)
-Ctx: OpenCiVera. Pool: .codex/state.yaml. Style: Quiet/Polished/Efficient.
-Own: app/globals.css, app/resume/resume.css, state.yaml#ui_critique, VisualQA routes.
-Rules:
-- Professional M2M Protocol: 100% YAML for PeerComm. NO social noise.
-- Critique/Recommend > DirectEdit. Log AC and viewport findings to state.yaml.
-- Principles: Clarity, Density, StrongHierarchy, StateDesign (Empty/Load/Err).
-- A11y: Keyboard, Focus, Contrast, Semantic HTML.
-- !Guard: NO edit API/Lib/Supabase. NO broad CSS rewrites.
-Collab: FE(ImplGuidance), Test(Visual/Regr), Arch(WorkflowRedesign).
->Out: YAML Status | TRIGGER(NEXT: Agent | CMD: Action | CTX: state_ref).
->Comm: Peer: SMI YAML Manifest; User: Concise Markdown Report.
+Read the repository-root AGENTS.md and the relevant linked procedures before working.
+Review the assigned screens against the current editor/portal design. Check hierarchy, density, empty/loading/error states, responsive behavior, keyboard/focus and contrast. Provide concrete findings and acceptance criteria; edit UI/CSS only when assigned, without API/database changes.
+
+Work only within the explicit file/responsibility scope of the assignment.
+You are not alone in the codebase: preserve others' edits and adapt to concurrent changes.
+Do not launch additional agents unless the user's scope or applicable instructions authorize it.
+Use concise, readable messages; include findings, changed files, actual validation and blockers.
+Follow .codex/runbooks/testing-and-validation.md. Do not require an absent state.yaml.
 """

--- a/.codex/checklists.md
+++ b/.codex/checklists.md
@@ -1,18 +1,16 @@
-# Checklists (OpenCiVera)
+# Codex checklists — quick entry point
 
-## Before changing YAML/contracts
-- Confirm the consuming renderer(s): legacy (`scripts/`) vs Next (`app/`).
-- Update both locales (PL/EN) for any new/changed keys.
-- Add fallback behavior for missing keys.
-- Run `npm test` (includes contract checks).
+Project rules: [AGENTS.md](../AGENTS.md).
 
-## Before changing auth/RBAC/admin
-- Identify the boundary: client-only legacy vs Next.js server routes.
-- Confirm Supabase migration requirements and RLS implications.
-- Ensure role constraints match docs (admin/manager restrictions).
-- Confirm privileged actions write to `admin_audit_logs`.
+For a task, use the applicable sections of the [task checklists](task-checklists.md).
+Validation commands and exceptions are maintained only in the
+[validation runbook](runbooks/testing-and-validation.md).
 
-## Definition of done (practical)
-- Lint/typecheck/tests pass: `npm run lint`, `npm run typecheck`, `npm test`.
-- Critical flows verified for touched area (auth, protected routes, locale switch, resume render, admin UI).
-- Docs updated if workflow/contract changes.
+- YAML/content: owners, schema, EN/PL labels, fallback and selected public output.
+- Auth/admin: actor verification, activity, role boundaries, RLS and audit.
+- UI: existing design tokens/components, both themes, responsive and keyboard checks.
+- Publication: snapshot-only reads, canonical link, unpublish/republish and retries.
+- Delivery: relevant docs, verification evidence and explicit deployment status.
+
+Do not use retired HTML pages or legacy browser scripts as current application
+test targets; use the [code map](site-map-and-dependencies.md).

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,6 @@
+# Project instructions: ../AGENTS.md
+# Setup and precedence: ../docs/guides/development/codex-setup.md
+# Agent limits are capacity settings, not a requirement to delegate every task.
 [agents]
 max_threads = 6
 max_depth = 1

--- a/.codex/instructions.md
+++ b/.codex/instructions.md
@@ -1,133 +1,19 @@
-# Codex Instructions (OpenCiVera)
+# Codex instructions — compatibility entry point
 
-## Mission
-Act as a senior Full-Stack JavaScript Architect and Technical Documentation Engineer for `OpenCiVera`.
+Read [AGENTS.md](../AGENTS.md) in the repository root. It is the canonical source
+for project working agreements, architecture boundaries, TDD and validation.
 
-Deliver small, safe, reversible changes with predictable outcomes.
+This file remains so existing references continue to work. It deliberately does
+not duplicate the root instructions.
 
-## Repo Reality (must respect)
-- Hybrid codebase:
-  - Legacy static app: root `*.html`, `scripts/`, `styles/`, `data/public/*.yaml`.
-  - Next.js rebuild: `app/` (App Router), TypeScript + React, server routes under `app/api/`.
-- Supabase is the source of truth for auth/data; migrations live in `supabase/migrations/`.
+- [Codex setup](../docs/guides/development/codex-setup.md)
+- [Project brief](project-brief.md)
+- [Code map](site-map-and-dependencies.md)
+- [Git workflow](../docs/guides/development/git-workflow.md)
+- [Validation runbook](runbooks/testing-and-validation.md)
+- [Task checklists](task-checklists.md)
+- [Task prompt template](prompt-templates.md)
 
-## Supabase CLI
-- Zainstalowany globalnie: `npm install -g supabase`
-- Use: `supabase db push` (push local migrations)
-- Use: `supabase pull` (pull schema z production)
-
-## Decision Priorities
-1. Security and data integrity
-2. Functional correctness
-3. Maintainability and readability
-4. Performance
-5. Delivery speed
-
-## Architecture & Change Discipline
-- Do not "rewrite" the legacy static app into React/TS; evolve incrementally and only inside `app/` when needed.
-- Preserve existing contracts (HTML route behavior, YAML shapes, DB schema/RLS expectations).
-- When changing YAML/content contracts, update both PL/EN consistently and ensure fallbacks.
-- Prefer explicit, boring solutions; avoid hidden magic.
-
-## Engineering Standards
-- JavaScript/TypeScript: modern syntax, `const` by default, small composable functions, explicit error handling.
-- Avoid adding inline comments unless the logic is genuinely non-obvious or security-sensitive.
-- Never hardcode secrets/keys; rely on env vars and documented setup.
-
-## Supabase / Auth Safety
-- Never weaken RLS/policies without explicit justification and review notes.
-- For auth/admin changes, verify role boundaries (`admin`/`manager`/`user`/`recruiter`) and audit logging.
-- Keep SQL migrations focused, reviewable, and safe to apply once (avoid destructive defaults).
-
-## Validation Expectations
-When changes affect related areas, validate:
-- `npm run lint`, `npm run typecheck`, `npm test`
-- Critical flows (as applicable): login/signup/reset, protected routes, locale switching, resume rendering, admin RBAC.
-
-### Testing discipline (mandatory)
-
-- Run the smallest relevant check after each meaningful change (see `.codex/runbooks/testing-and-validation.md`).
-- Before considering a task â€śdoneâ€ť, run the full default suite:
-  - `npm run lint`
-  - `npm run typecheck`
-  - `npm test`
-- If you cannot run a command (environment restriction), document what you ran instead and why.
-
-## Git workflow (branches + commits)
-
-See `docs/guides/development/git-workflow.md` for the branching rule, branch naming convention, and commit message convention (canonical source, shared with Claude Code via `CLAUDE.md`).
-
-## Docs to consult (authoritative)
-- `README.md`
-- `docs/README.md`
-- `docs/guides/phase-b-yaml-data-layer.md`
-- `docs/guides/phase-c-auth-rbac-admin.md`
-- `.codex/site-map-and-dependencies.md`
-- `.codex/prompt-templates.md`
-- `.codex/task-checklists.md`
-- `.codex/runbooks/testing-and-validation.md`
-- `.codex/runbooks/supabase-migrations.md`
-- `.codex/runbooks/rls-review.md`
-
-## Output Style
-- Prefer "code first, then short explanation".
-- Summaries: plan > changes > risks/trade-offs > test results.
-
-## Prompt template (copy/paste)
-
-Use this template when asking Codex to implement changes. It forces scope discipline, plan awareness, and verification.
-
-### Title
-`[CHANGE] <short name> (Phase <X>, route <path>, scope <area>)`
-
-### Git (branch + commits)
-- Branch name (if starting from `master`/`main`):
-- Expected commit type(s) (`feat:`/`fix:`/`docs:`/etc.):
-
-### Goal
-- Primary outcome:
-- Non-goals (explicitly out of scope):
-
-### Sources of truth (must consult)
-- `docs/guides/saas-transition-work-plan.md`
-- `.codex/site-map-and-dependencies.md`
-- Other relevant guides (list exact paths):
-
-### Scope (what to change)
-- Routes/pages:
-- Files/directories:
-- Data contracts touched (YAML keys, DB tables, API payloads):
-
-### Constraints / guardrails
-- Migration strategy: incremental, parity-gated (no big-bang rewrite).
-- Do not weaken Supabase RLS/policies.
-- Keep EN/PL locale parity for any YAML/i18n key changes.
-- No secrets in repo; use env vars only.
-
-### Definition of Done (DoD)
-- Automated:
-  - `npm run lint`
-  - `npm run typecheck`
-  - `npm test`
-- Manual QA (checklist):
-  - Auth: signup/verify/signin/signout (if touched)
-  - Protected routes: redirects and role boundaries (if touched)
-  - Resume rendering: locale switching EN/PL (if touched)
-  - Editor publish + rollback (if touched)
-  - Public view: `/r/[slug]` behavior + indexing controls (if touched)
-
-### Rollout / rollback
-- Rollout approach (feature flag / route fallback / staged deploy):
-- Rollback plan (how to revert safely):
-
-### Deliverables
-- Code changes:
-- Docs updates:
-- Risks/trade-offs:
-
-### Instructions to Codex
-- Use `update_plan` and keep it current (exactly one `in_progress` step).
-- If the current branch is `master` or `main`, create a new branch before making changes.
-- Make small, reversible commits (no mass refactors).
-- Validate against DoD and report results + any blockers.
+Read the relevant linked documents for the task; do not load every historical
+plan or design prompt by default.
 

--- a/.codex/project-brief.md
+++ b/.codex/project-brief.md
@@ -1,32 +1,48 @@
-# Project Brief (OpenCiVera)
+# Project brief — OpenCiVera
 
-## What this repo is
-`OpenCiVera` is a hybrid project:
-- Legacy static resume app (served from `public/` as HTML entry pages + browser scripts + YAML content).
-- In-progress Next.js SaaS rebuild (App Router).
+OpenCiVera is a Next.js App Router application for building a private Master CV,
+creating tailored saved versions, and sharing published CVs through public links.
+React and TypeScript implement the UI and route handlers. Supabase provides
+authentication, roles, persistence, publication and audit behavior.
 
-## Key contracts
-- Public locale content: `public/data/public/locales.yaml`, `public/data/public/resume-en.yaml`, `public/data/public/resume-pl.yaml`.
-- Legacy UI behavior is driven by `public/scripts/` + `public/styles/` and should remain stable.
-- Next.js app (`app/`) introduces auth + RBAC + admin workflows backed by Supabase.
+The static HTML application is retired. `public/` now holds assets, sample/template
+YAML, vendor runtime files and historical migration helpers. It is not a parallel
+application. Styling is implemented in shared and feature CSS, including editor
+tokens in `app/globals.css`; do not assume a Tailwind migration.
 
-## Where things live
-- Static pages: `public/*.html`
-- Legacy JS: `public/scripts/`
-- Legacy CSS: `public/styles/`
-- Next.js: `app/`, config in `next.config.ts`, `tsconfig.json`
-- Supabase SQL: `supabase/migrations/`
-- Guides/checklists: `docs/`
-- Tests: `tests/` (Node test runner via `node --test`)
+## Data model
 
-## Common commands
-- Dev (Next): `npm run dev`
-- Lint: `npm run lint`
-- Typecheck: `npm run typecheck`
-- Tests: `npm test`
-- CI bundle: `npm run ci`
+| Concept | Storage | Meaning |
+| --- | --- | --- |
+| Master CV | `resume_documents` | Private editable YAML per language |
+| Revision | `resume_revisions` | Master CV history and rollback source |
+| Saved CV | `resume_presets`, `resume_preset_variants` | Selected content and language configuration |
+| Published CV | `resume_published_cvs`, `resume_published_cv_locales` | Immutable publication snapshots |
+| Public identity | `resume_public_links` | Canonical path, active snapshot and indexing controls |
+| First use | `resume_onboarding` | Normal guide progress and first saved CV reference |
+| Admin test | `resume_onboarding_test_runs` | Isolated test drafts and progress |
 
-## High-risk areas (extra caution)
-- Supabase RLS/policies and `security definer` functions
-- Auth/session cookies and protected route gating
-- YAML schema/key changes across locales
+Public links use `/{personSlug}/{publicId}`. Anonymous rendering and exports must
+use the publication snapshot resolver and apply the saved selection. Private
+Master CV data outside that selection must not be served.
+
+Roles are `admin`, `manager`, `user` and `recruiter`. Capability inheritance
+does not grant private CV access across accounts. English and Polish content,
+labels and fallbacks must stay consistent when contracts change.
+
+For normal onboarding, changes are saved to the account's Master CV. Admin tests
+reuse the guide with separate drafts; their optional publication is named
+`Test onboardingu`, and must preserve the real Master CV, profile and languages.
+
+## Start here
+
+- [Project rules](../AGENTS.md)
+- [Setup and commands](../README.md)
+- [Code map](site-map-and-dependencies.md)
+- [Validation](runbooks/testing-and-validation.md)
+- [Publication contract](../docs/guides/testing/cv-publication-test-contracts.md)
+- [Onboarding behavior](../docs/guides/features/first-use-master-cv.md)
+- [Dated roadmap](../docs/STATUS.md)
+
+The roadmap records planning status; inspect current code and deployment evidence
+before claiming a feature is running on a shared environment.

--- a/.codex/prompt-templates.md
+++ b/.codex/prompt-templates.md
@@ -1,120 +1,38 @@
-# Prompt Templates (OpenCiVera)
+# Task prompt template — OpenCiVera
 
-Use these templates to start new tasks. They are designed to keep scope small, follow the repo plans, and enforce validation and rollback discipline.
+Use this template when details are useful; a clear short request is enough for a
+small change. [AGENTS.md](../AGENTS.md) supplies the standing project rules.
 
----
+## Request
 
-## Template: Small change (docs / minor refactor)
+**Outcome:** What should users be able to do, and what currently happens?
 
-**Title**
-`[CHANGE] <short name> (scope <area>)`
+**Scope:** Routes, affected modules and data owners. State exclusions only when
+they matter for the task.
 
-**Goal**
-- Primary outcome:
-- Non-goals:
+**References:** Relevant feature guide, ADR or existing UI to match. Use the
+[code map](site-map-and-dependencies.md) and [guide index](../docs/guides/README.md)
+to find current paths.
 
-**Scope**
-- Files/directories:
-- Out of scope:
+**Acceptance criteria:** Observable success, error/retry behavior, applicable
+roles, languages and screen sizes.
 
-**Definition of Done**
-- `npm run lint`
-- `npm run typecheck`
-- `npm test`
+**Delivery:** Local implementation, draft PR, or deployment to a named environment.
+Use the current [Git workflow](../docs/guides/development/git-workflow.md).
 
-**Instructions to Codex**
-- Use `update_plan` and keep it current.
-- If current branch is `master`/`main`, create a new branch before changing files.
+**Validation:** Follow the [validation runbook](runbooks/testing-and-validation.md).
+For behavior changes, write a failing regression test first. Report actual results
+and any checks that remain unexecuted.
 
----
+## Add details only when relevant
 
-## Template: Phase E slice (public resume: `/r/[slug]`)
+- **UI:** visual reference, theme, desktop/mobile behavior and keyboard interaction.
+- **Publication:** snapshot/selection behavior, canonical link, locales and indexing.
+- **Auth/admin:** permitted roles, ownership boundary and audit expectations.
+- **Database:** new migration, existing-data impact, target environment and rollback.
+- **YAML:** affected fields, EN/PL parity, import/export and fallback expectations.
 
-**Title**
-`[CHANGE] Phase E: public resume by slug (route /r/[slug])`
-
-**Sources of truth (must consult)**
-- `docs/guides/saas-transition-work-plan.md`
-- `.codex/site-map-and-dependencies.md`
-- `docs/guides/deployment-qa.md`
-
-**Goal**
-- Implement SSR/ISR rendering for `/r/[slug]` using `resume_public_links` + `resume_documents`.
-- Enforce `allow_indexing` behavior in robots/meta.
-
-**Non-goals (out of scope)**
-- Do not migrate legacy HTML pages.
-- Do not change YAML schema unless explicitly required (and then update both EN/PL + validation).
-
-**Scope**
-- `app/r/[slug]/page.tsx` (+ supporting `app/lib/*` helpers as needed)
-- SEO metadata (`Metadata` / `generateMetadata`)
-- Optional: `robots.txt` / sitemap strategy, but keep it minimal and aligned with Phase E plan.
-
-**Definition of Done**
-- Automated: `npm run lint`, `npm run typecheck`, `npm test`
-- Manual QA:
-  - Open `/r/<slug>` for an active public link.
-  - Verify 404/“not found” for inactive/missing slug.
-  - Verify robots meta toggles with `allow_indexing`.
-  - Verify EN/PL locale selection rules (documented behavior).
-
-**Rollout / rollback**
-- Define safe rollout (feature flag or staged route enablement) if behavior could regress SEO.
-- Provide rollback steps (revert PR + confirm legacy redirects still work).
-
----
-
-## Template: Supabase migration change (schema/RLS/RPC)
-
-**Title**
-`[CHANGE] Supabase migration: <what> (Phase <X>)`
-
-**Sources of truth (must consult)**
-- `docs/guides/phase-c-supabase-schema-setup.md` (if relevant)
-- `docs/guides/phase-b-yaml-data-layer.md` / `docs/guides/phase-c-auth-rbac-admin.md` (as applicable)
-
-**Goal**
-- What is changing (tables, policies, functions) and why:
-
-**Non-goals**
-- No destructive changes without explicit rollback plan.
-
-**Scope**
-- New migration file under `supabase/migrations/` (do not edit already-applied migrations for production environments).
-- Frontend/backend changes needed to match the contract.
-
-**Definition of Done**
-- Automated: `npm test` (migration-related tests) + `npm run lint` + `npm run typecheck`
-- Documentation:
-  - Update the relevant guide(s) and describe impact.
-
-**Rollback / safety**
-- Add rollback notes (new rollback migration if needed).
-- Call out data migration risk and how to back up before apply.
-
----
-
-## Template: YAML contract change (public locale data)
-
-**Title**
-`[CHANGE] YAML contract: <field/key change> (public data)`
-
-**Sources of truth (must consult)**
-- `data/public/locales.yaml`
-- `scripts/phase-b/resume-yaml-contract.js`
-- `.codex/site-map-and-dependencies.md`
-
-**Goal**
-- Define the new/changed key(s) and how they render.
-
-**Scope**
-- Update both `data/public/resume-en.yaml` and `data/public/resume-pl.yaml` consistently.
-- Update any configs under `data/public/config/*` if labels are needed.
-- Update validators/tests that enforce the contract.
-
-**Definition of Done**
-- Automated: `npm test`
-- Manual QA:
-  - Load `resume.html` and verify EN/PL parity + rendering.
+Let Codex resolve routine implementation choices within the requested scope.
+Do not require specific planning tools, skills or subagents unless available and
+needed for the task.
 

--- a/.codex/runbooks/testing-and-validation.md
+++ b/.codex/runbooks/testing-and-validation.md
@@ -1,39 +1,78 @@
-# Runbook: Testing and validation (Codex workflow)
+# Testing and validation — Codex workflow
 
-This project expects changes to be validated with automated checks and relevant manual flows.
+Working rules: [AGENTS.md](../../AGENTS.md).
+Use checks that can detect regressions in the requested behavior.
 
-## Default automated suite (run before task completion)
+## TDD for behavior changes
 
-- `npm run lint`
-- `npm run typecheck`
-- `npm test`
+1. Reproduce the missing/incorrect behavior with the smallest relevant test.
+2. Run it before implementation and confirm the expected failure.
+3. Implement the smallest change that makes the test pass.
+4. Refactor while keeping the test passing; reuse existing code and fixtures.
+5. Run the default suite before declaring code changes complete.
 
-Shortcut:
-- `npm run verify` (runs lint + typecheck + test)
+Prefer behavioral tests of outputs, interactions, roles, ownership and failures.
+For visual changes, a reproducible failing browser check can establish the
+regression; do not create artificial unit tests for copy or CSS declarations.
+Keep reusable automated regression checks in the repository when practical.
 
-## After every modification guidance
+## Default suite
 
-Not every keystroke warrants a full CI run, but every meaningful change should be followed by the smallest relevant check:
+On Windows PowerShell:
 
-- Docs-only change:
-  - run `npm test` only if docs imply behavior/workflow changes; otherwise skip with justification.
-- Frontend/Next change:
-  - run `npm run lint` + `npm run typecheck` as soon as the code compiles cleanly.
-  - run `npm test` before finishing the task.
-- Supabase migration / contract change:
-  - run `npm test` immediately after updating contract/migration logic.
+```powershell
+npm.cmd run verify
+```
 
-## Manual QA triggers (when applicable)
+This runs `npm.cmd run lint`, `npm.cmd run typecheck` and `npm.cmd test`.
+On other platforms use `npm run verify`. The package scripts are the command
+source of truth.
 
-- Auth: signup/verify/signin/signout, session refresh, protected routes.
-- Resume: locale switching, public vs private rendering, publish/rollback.
-- Admin: role boundaries + audit logging.
-- Public SEO: robots meta, canonical URL, indexing controls, 404 behavior.
+For a focused Node test:
 
-## Reporting (in the final recap)
+```powershell
+node --test tests/onboarding-progress.test.mjs
+```
 
-- Commands run + pass/fail.
-- Manual steps executed (short checklist).
-- Known limitations or blockers (with next steps).
+Run the smallest relevant check after a meaningful implementation change.
+For frontend/Next changes, run lint and typecheck once the code is ready.
+Broaden checks when changes, failures or unresolved concerns justify it; avoid
+rerunning unchanged passing suites without a reason.
+
+For build/deployment-sensitive changes, use `npm.cmd run build` or
+`npm.cmd run ci` as appropriate to the task.
+
+## Documentation-only changes
+
+Check referenced files, Markdown links, example commands and consistency with
+current code. Run `npm.cmd test` when changing development/testing workflows.
+Lint/typecheck/build can be omitted when no application or executable configuration
+changes; report the reason. Do not describe documented manual scenarios as executed.
+
+## Browser and integration checks
+
+- **UI:** desktop/mobile, dark/light, relevant EN/PL copy, keyboard/focus, dialogs,
+  overflow and the shared shell after navigating away.
+- **Auth:** signup/verify/signin/signout, refresh and protected redirects when affected.
+- **Admin/RBAC:** anonymous, user, recruiter, manager and admin boundaries, activity,
+  verification, cross-account isolation and audit behavior.
+- **Resume:** locale switching, draft save/load, import, revisions/rollback, export.
+- **Publication:** selected snapshot content, consent, retries, stable links,
+  unpublish/republish and no private-data fallback.
+- **Public SEO:** canonical identity, locale selection, indexing and missing/inactive links.
+- **Onboarding:** [User and Admin scenarios](../../docs/guides/test-scenarios/ONBOARDING_TEST_SCENARIOS.md).
+- **SQL:** validate the actual new migration and policies/RPCs in an isolated
+  environment; identify any real Supabase staging checks still needed.
+
+Preserve existing development servers. Reuse an appropriate server or create an
+isolated test instance; do not stop the user's process merely to free a port/lock.
+Use test data for publication checks.
+
+## Reporting
+
+State the commands and outcomes, browser checks actually performed, and remaining
+failures or unavailable checks. Identify mocked services and isolated databases;
+they do not establish that production or real Supabase integration was tested.
+Distinguish local completion, migration application, push and deployment.
 
 

--- a/.codex/site-map-and-dependencies.md
+++ b/.codex/site-map-and-dependencies.md
@@ -1,262 +1,71 @@
-# Site Map and Dependency Guide (OpenCiVera, formerly resume-studio)
+# OpenCiVera code map
 
-This document explains **what happens in the project**, how the individual pages work, and what the dependencies are between:
-- the legacy static pages (`public/*.html` + `public/scripts/` + `public/styles/` + `public/data/public/*.yaml`),
-- the Next.js rebuild (`app/`),
-- the Supabase auth/data layer (`supabase/migrations/`).
+Use this map to locate the relevant implementation, then inspect that code.
+Working rules live in [AGENTS.md](../AGENTS.md); the domain overview is in the
+[project brief](project-brief.md).
 
-> This repository is hybrid: the legacy app is “static-first”, while the Next.js app is a parallel track (SaaS rebuild). Avoid mixing responsibilities between these two worlds unless there is a clear need.
+## Application routes
 
----
+| Route | Entry point | Responsibility |
+| --- | --- | --- |
+| `/` | [Home](../app/page.tsx) | Landing page |
+| `/login` | [Login](../app/login/page.tsx) | Authentication UI |
+| `/dashboard` | [Dashboard](../app/dashboard/page.tsx) | Saved CVs and publication management |
+| `/master-resume` | [Master Resume](../app/master-resume/page.tsx) | Private editor |
+| `/onboarding` | [Guide](../app/onboarding/page.tsx) | First CV; admin test selected by query parameter |
+| `/settings` | [Settings](../app/settings/page.tsx) | Admin-only onboarding test controls |
+| `/user` | [Personal Hub](../app/user/page.tsx) | Account workspace |
+| `/admin` | [Administration](../app/admin/page.tsx) | Staff tools with operation-specific RBAC |
+| `/resume` | [Sample CV](../app/resume/page.tsx) | Public sample |
+| `/{personSlug}/{publicId}` | [Published CV](../app/[personSlug]/[publicId]/page.tsx) | Public snapshot rendering |
+| `/docs` | [Documentation](../app/docs/page.tsx) | In-app documentation with its own access rules |
 
-## 1) Quick overview
+The old static HTML entry points and `/r/[slug]` route are retired. Do not create
+a static-server test path for them. [Netlify configuration](../netlify.toml) defines
+the current build/plugin setup.
 
-### Legacy (static HTML)
-- Each page under `public/` (`resume.html`, `login.html`, `dashboard.html`, `master-resume.html`, `user.html`) is a separate entry point.
-- Behavior is driven by browser scripts in `public/scripts/` (no bundler) and styles in `public/styles/`.
-- Public/demo data lives in YAML (`public/data/public/*.yaml`) and is parsed in the browser via `public/scripts/js-yaml.min.js`.
+## Ownership boundaries
 
-### Next.js (App Router)
-- `app/` is the target direction: React + TypeScript + API routes.
-- Netlify currently provides the full compatibility redirect matrix for legacy URLs. `next.config.ts` only keeps the minimal in-app redirect.
-- Auth and roles (RBAC) are based on Supabase and cookies (API routes under `app/api/auth/*`).
+| Area | Relevant implementation | Contract/reference |
+| --- | --- | --- |
+| Session and identity | [Server auth](../app/lib/auth-server.ts), [request auth](../app/lib/auth-request.ts), [proxy](../proxy.ts), `app/api/auth/` | [Auth/RBAC phase](../docs/phases/phase-c-auth-rbac-admin.md) |
+| Roles and audit | [RBAC](../app/lib/rbac.ts), [admin audit](../app/lib/admin-audit.ts), `app/api/admin/` | [Privacy policy](../docs/guides/policies/privacy-first-admin-access-policy.md) |
+| Editor and languages | [Editor canvas](../app/master-resume/editor-canvas-client.tsx), [locale buffers](../app/master-resume/use-multi-locale-resume-documents.ts) | [Multi-locale ADR](../docs/adr/0017-multi-locale-master-resume-editor-tabs.md) |
+| Schema and data | [Resume schema](../app/lib/resume-schema.ts), [resume server](../app/lib/resume-server.ts), [Supabase HTTP](../app/lib/supabase-http.ts) | [YAML contract](../docs/guides/policies/opencv-yaml-public-contract-policy.md) |
+| Publication/export | `app/api/resume/presets/`, [resume server](../app/lib/resume-server.ts), `app/api/public/opencv/v1/` | [Public API policy](../docs/guides/policies/opencv-public-api-export-policy.md) |
+| Rendering | `app/components/resume-renderer/`, [live preview](../app/master-resume/resume-live-preview.tsx), `app/lib/pdf/` | [Rendering ADR](../docs/adr/0014-pdf-rendering-architecture.md) |
+| Styling | [Shared CSS](../app/globals.css), [theme](../app/lib/app-theme.ts), feature CSS | [Responsive UI patterns](../docs/guides/development/responsive-ui-and-drawer-patterns.md) |
+| Onboarding | `app/onboarding/`, `app/api/resume/onboarding/`, `app/api/admin/onboarding-test/` | [Feature guide](../docs/guides/features/first-use-master-cv.md) |
 
-### Supabase
-- SQL migrations in `supabase/migrations/` define tables, RLS/policies, RPC functions, and triggers.
-- The project is organized into phases (B/C/D) that map to layers: YAML data layer, auth+RBAC+admin, editor/templates.
+Protected pages use server-side actor checks; API handlers enforce their own
+authorization. The proxy supports session refresh and request security, but is
+not a substitute for endpoint checks or database policies.
 
----
+## Core data flows
 
-## 2) Site map
+1. **Editing:** forms/YAML → locale buffers → resume API → owned
+   `resume_documents` and `resume_revisions`.
+2. **Normal publication:** saved CV selection → publication service/RPC →
+   immutable `resume_published_cvs` and locale snapshots → active
+   `resume_public_links` pointer.
+3. **Public read/export:** canonical identity → active link → snapshot resolver →
+   selected content. Do not read live Master CV as a fallback.
+4. **Admin onboarding test:** separate test draft/progress → dedicated admin RPC →
+   optional test preset and publication snapshots. Normal Master CV remains unchanged.
 
-### Legacy: static entry pages (`public/`)
-- `public/resume.html` - public resume view (public, YAML + locale switch).
-- `public/login.html` - legacy login.
-- `public/dashboard.html` - legacy dashboard.
-- `public/master-resume.html` - legacy configuration/editing.
-- `public/user.html` - legacy “user/editor mode” view.
-- `public/editor-preview.html` - editor preview/canvas.
-- `public/r/index.html` - legacy public share entry.
+See the [publication test contracts](../docs/guides/testing/cv-publication-test-contracts.md)
+and [onboarding scenarios](../docs/guides/test-scenarios/ONBOARDING_TEST_SCENARIOS.md)
+before changing these flows.
 
-### Next.js: App Router (`app/`)
-- `app/page.tsx` - home (“OpenCiVera Rebuild”).
-- `app/login/page.tsx` - login UI (frontend for auth API).
-- `app/dashboard/page.tsx` - post-login dashboard.
-- `app/master-resume/page.tsx` - master resume (SaaS rebuild).
-- `app/resume/page.tsx` - resume view in Next.
-- `app/user/page.tsx` - user view in Next.
-- `app/admin/page.tsx` - admin panel (RBAC).
-- `app/r/[slug]/page.tsx` - public link / short resume URL (slug).
+## Assets and persistence
 
-### Legacy -> Next redirects
-+Source: `netlify.toml` (authoritative) and `next.config.ts` (minimal in-app fallback)
-- `/index.html` -> `/`
-- `/login.html` -> `/login`
-- `/dashboard.html` -> `/dashboard`
-- `/master-resume.html` -> `/master-resume`
-- `/resume.html` -> `/resume`
-- `/user.html` -> `/user`
-- `/r/index.html` -> `/resume`
+- `public/data/public/`: sample YAML and locale/config labels.
+- `public/data/private/`: template YAML; preserve access rules.
+- `public/vendor/`: browser runtimes; treat as vendor code.
+- `public/scripts/phase-b/`: historical migration/contract helpers, not the app UI.
+- `supabase/migrations/`: append-only history for shared environments. Later
+  migrations can replace earlier function/policy definitions; inspect the latest
+  applicable definition as well as the original table contract.
+- `tests/`: Node test suites; some integration checks require explicit environment setup.
 
----
-
-## 3) Legacy: modules and dependencies
-
-### Key scripts
-- `public/scripts/main.js`
-  - the legacy “hub”: YAML loading, i18n, section rendering, language switching, resource caching, admin unlock/presets.
-  - depends on `public/scripts/js-yaml.min.js` (global `jsyaml`).
-  - reads `public/data/public/locales.yaml`, then uses `resume_path` and `config_path` for the active locale.
-- `public/scripts/public-resume.js`
-  - resume section renderer (DOM rendering: summary, contact, skills, experience, QR, etc.).
-  - invoked by `scripts/main.js` after the profile is loaded.
-- `public/scripts/admin-config.js`
-  - configuration panel UI for section visibility and presets (localStorage).
-  - coordinates with `scripts/main.js` (storage keys, preset query param `version`).
-- `public/scripts/master-resume-editor.js`
-  - legacy master resume editor logic.
-- `public/scripts/editor-preview-renderer.js`
-  - renderer for preview/canvas in `editor-preview.html`.
-- `public/scripts/auth.js`, `public/scripts/protected.js`
-  - legacy auth/gating (separate from Next auth).
-
-### Data contracts (legacy YAML)
-- `public/data/public/locales.yaml`
-  - `default_locale`
-  - `locales[]`:
-    - `code`, `label`
-    - `resume_path` (e.g. `data/public/resume-en.yaml`)
-    - `config_path` (e.g. `data/public/config/en.yaml`)
-- `public/data/public/resume-en.yaml`, `public/data/public/resume-pl.yaml`
-  - profile data + section arrays (e.g. `name`, `role`, `summary`, `experience[]`, ...).
-  - may include `labels` (at the resume level) that are merged with config labels.
-- `public/data/public/config/<locale>.yaml` (as referenced by `locales.yaml`)
-  - typically: `labels`, `locale`, `language_name`.
-
-### i18n and fallback
-- `public/scripts/main.js` defines `FALLBACK_LABELS` and builds `activeLabels` as:
-  - fallback -> `resumeData.labels` -> `configData.labels`.
-- The active language is stored in `localStorage` (`resume-studio:locale`).
-
-### Resource cache
-- `public/scripts/main.js` implements a cache with TTL (~10 min): prefix `resume-studio:cache:`.
-- Used for fetching YAML/config so locale switching is responsive.
-
-### Admin unlock/presets (legacy)
-- Password: `window.ADMIN_PASSWORD` (normalized), unlock state and presets stored in `localStorage`.
-- Storage keys (examples):
-  - `resume-studio:admin-unlocked`
-  - `resume-studio:presets:v2`
-  - `resume-studio:active-preset:v2`
-  - `resume-studio:item-visibility:v1`
-
----
-
-## 4) Next.js: modules and dependencies
-
-### Layers
-- Pages/UI: `app/**/page.tsx`, client components in `app/**/**-client.tsx`.
-- API: `app/api/**/route.ts`.
-- Libraries: `app/lib/*` (auth cookies, RBAC, Supabase HTTP, schema, etc.).
-
-### Auth (Next)
-- API endpoints (see `docs/guides/phase-c-auth-rbac-admin.md` + `app/api/auth/*`):
-  - `POST /api/auth/signup`
-  - `POST /api/auth/signin`
-  - `POST /api/auth/reset-password`
-  - `POST /api/auth/resend-verification`
-  - `POST /api/auth/signout`
-  - `GET /api/auth/session`
-  - `POST /api/auth/update-password`
-- Cookies:
-  - set/read by `app/lib/auth-cookies.ts` (used by `app/api/auth/*`).
-- Session control:
-  - `GET /api/auth/session` refreshes via refresh token and clears cookies when needed.
-- Verification:
-  - `signin` requires `email_confirmed_at` and `profiles.is_active`.
-
-### RBAC
-- Roles: `admin`, `manager`, `user`, `recruiter`.
-- Enforcement:
-  - in the database (RLS + guarded RPC functions),
-  - in Next (route protection + role checks in pages/admin UI).
-
-### Resume (Next)
-- API endpoints:
-  - `app/api/resume/document/route.ts`
-  - `app/api/resume/presets/[presetId]/publish/route.ts`
-  - `app/api/resume/presets/[presetId]/unpublish/route.ts`
-- Server-side domain logic: `app/lib/resume-server.ts` + `app/lib/resume-schema.ts`.
-- Publish RPC integration:
-  - `publishResumePreset` in `app/lib/resume-server.ts` calls `publish_resume_saved_version`.
-  - Route-level validation errors return `400` for malformed request payloads.
-  - RPC/runtime errors are currently forwarded as descriptive messages with `500`.
-
----
-
-## 5) Supabase: schema, migrations, dependencies
-
-### Migrations (order and intent)
-Source: `README.md` + files in `supabase/migrations/`.
-- `20260405000000_phase_c_foundation.sql`
-  - foundation: base tables (e.g. `profiles`), triggers, baseline RLS.
-  - the `handle_new_auth_user()` trigger creates a profile when a row is inserted into `auth.users`.
-- `20260410000000_phase_b_yaml_data_layer.sql`
-  - YAML-first: documents, revisions, public links, legacy JSON -> YAML backfill, role-aware RLS.
-  - RBAC helpers: `current_user_role()`, `is_staff_user()`, etc.
-- `20260410010000_phase_c_auth_rbac_admin.sql`
-  - admin RPC + audit:
-    - `log_admin_action`, `set_user_role`, `set_user_active`, `get_staff_user_overview`, `can_delete_user_account`.
-- `20260409000000_phase_d_yaml_template_iteration.sql`
-  - editor iteration built around YAML templates.
-- `20260508000000_cv_publication_foundation.sql`
-  - publication schema foundation (`resume_published_cvs`, `resume_published_cv_locales`, public-link coupling, RLS for published snapshots).
-- `20260509000000_cv_publication_rpc_atomic.sql`
-  - atomic publish/unpublish RPCs for saved versions and public link activation.
-- `20260510000000_fix_publish_rpc_variant_fallback.sql`
-  - ADR 0009 fix: publish no longer requires explicit variant rows for every locale.
-  - locale snapshots use variant selection when available, otherwise fallback to base preset selection.
-  - preserves descriptive SQL exceptions for publish diagnostics.
-
-### Key logical dependencies
-- Next auth works correctly only if:
-  - `profiles` exists and the trigger on `auth.users` inserts is in place,
-  - RLS/policies and RPC match the role model,
-  - the frontend reads the profile after login (`/api/auth/session`, `signin`).
-- The resume layer (YAML-first) assumes:
-  - document/revision/public link tables exist,
-  - publish/unpublish RPC constraints and helpers exist,
-  - publication snapshot tables and locale-level snapshot rows exist,
-  - YAML contract is kept consistent (tests in `tests/`).
-- Multi-locale publish (ADR 0009) additionally assumes:
-  - each selected locale has an owned `resume_documents` row,
-  - `resume_preset_variants` may be partial (missing locale rows are allowed by fallback),
-  - fallback snapshot selection is `coalesce(variant.selection, preset.selection)`.
-
----
-
-## 6) Dependency flow (how things connect)
-
-### Legacy render (public resume)
-1. `public/resume.html` loads `public/scripts/js-yaml.min.js` + `public/scripts/main.js` (+ renderers).
-2. `public/scripts/main.js`:
-   - fetches `public/data/public/locales.yaml`,
-   - selects a locale (default or from `localStorage`),
-   - fetches `resume_path` and `config_path`,
-   - parses YAML (`jsyaml.load`) and validates basic shapes,
-   - builds `activeLabels` (fallback + resume + config),
-   - renders the UI and the language switcher.
-
-### Next auth/session
-1. The `/login` UI calls `POST /api/auth/signin`.
-2. `signin`:
-   - validates email/password,
-   - calls Supabase,
-   - enforces `email_confirmed_at`,
-   - fetches the profile and checks `is_active`,
-   - sets auth cookies.
-3. Protected pages rely on cookies and `GET /api/auth/session` (refresh + profile lookup).
-
-### Admin (Next)
-- `/admin` and `/api/admin/users/*` require staff role (admin/manager) and use RPC/audit logging from Phase C migrations.
-
----
-
-## 7) Where to change what (practical guide)
-
-### You want to change resume content (public/demo)
-- `public/data/public/resume-en.yaml` and `public/data/public/resume-pl.yaml`.
-- If you add new label keys/fields: keep EN/PL in sync.
-
-### You want to change legacy UI headings/labels
-- `public/data/public/config/en.yaml`, `public/data/public/config/pl.yaml` (labels), or `labels` inside the resume YAML.
-- Fallbacks live in `public/scripts/main.js` (`FALLBACK_LABELS`).
-
-### You want to change locale switching or fetch/caching behavior
-- `public/scripts/main.js`.
-
-### You want to change section rendering (DOM)
-- `public/scripts/public-resume.js`.
-
-### You want to change auth / RBAC / admin in Next
-- API: `app/api/auth/*`, `app/api/admin/*`.
-- Libraries: `app/lib/auth-*.ts`, `app/lib/rbac.ts`.
-- DB: `supabase/migrations/*phase_c*`.
-
----
-
-## 8) Risks and checkpoints
-
-- YAML contracts: key changes must be synchronized between `en` and `pl` and stay aligned with validation/tests (`tests/`, `public/scripts/phase-b/resume-yaml-contract.js`).
-- Security: do not weaken RLS or `security definer` functions without fully reviewing the implications.
-- Legacy vs Next: redirects suggest URL convergence, but logic is still duplicated — avoid implicitly mixing auth states.
-
----
-
-## 9) Recommended tests / verifications
-
-- Legacy smoke:
-  - run a static server (`npx serve .`) and verify `public/resume.html` + locale switching.
-- Next.js:
-  - `npm run lint`, `npm run typecheck`, `npm test`, `npm run dev`.
-- Auth flows (Next): signup -> verify email -> signin -> `/dashboard` -> `/admin` (for staff).
+Run and report checks according to the [validation runbook](runbooks/testing-and-validation.md).

--- a/.codex/task-checklists.md
+++ b/.codex/task-checklists.md
@@ -1,67 +1,60 @@
-# Task Checklists (OpenCiVera)
+# Task checklists — OpenCiVera
 
-Use these checklists while implementing changes. Copy the relevant section into your task description and mark items as you go.
+Use only the sections relevant to the requested change.
+[AGENTS.md](../AGENTS.md) defines working rules; the
+[validation runbook](runbooks/testing-and-validation.md) defines required commands.
 
----
+## General delivery
 
-## Checklist: General PR hygiene
+- [ ] Outcome and acceptance criteria are clear.
+- [ ] Existing working-tree changes and development servers are preserved.
+- [ ] Git naming follows the current [workflow](../docs/guides/development/git-workflow.md).
+- [ ] Changed behavior has a regression test that failed before the implementation.
+- [ ] Relevant validation passes; unavailable checks are identified honestly.
+- [ ] Guides, contracts and manual scenarios reflect the change.
+- [ ] Rollout/rollback and local/pushed/deployed status are explicit where applicable.
 
-- Scope is explicit; out-of-scope is explicit.
-- Rollout/rollback plan exists (even if it is “revert this PR”).
-- No secrets added to repo; env vars documented if needed.
-- Docs updated if behavior/workflow changed.
+## Auth/session/admin
 
----
+- [ ] Signup, verification, signin/signout and refresh work when affected.
+- [ ] Inactive/unverified accounts cannot use restricted operations.
+- [ ] Anonymous access and each affected role boundary are tested.
+- [ ] APIs derive the actor/owner from the session.
+- [ ] Privileged actions preserve audit behavior without logging private CV content.
 
-## Checklist: Testing + validation (mandatory at task completion)
+## Supabase / RLS / RPC
 
-- `npm run lint`
-- `npm run typecheck`
-- `npm test`
-- If any command cannot be run locally, record why and what was run instead.
+- [ ] Shared-environment changes use a new migration.
+- [ ] Own-account and cross-account access are tested at API and database boundaries.
+- [ ] RPCs validate inputs, privileges and ownership independently.
+- [ ] Security-definer functions are minimal and use a safe search path.
+- [ ] Retries/concurrency do not duplicate publications or overwrite unrelated data.
+- [ ] Data impact, migration order, target environment and rollback are documented.
+- [ ] Isolated/mocked checks are distinguished from real Supabase checks.
 
----
+## YAML / language / rendering
 
-## Checklist: Auth/session changes (Next.js)
+- [ ] EN/PL schema and label changes preserve parity and fallback.
+- [ ] Sample locale paths in `public/data/public/locales.yaml` resolve.
+- [ ] Import, normal editing and export honor the same data contract.
+- [ ] Editor preview and public rendering show the intended selected data.
+- [ ] Relevant validators and behavioral contract tests are updated.
 
-- Sign up (if applicable) and confirm verification email behavior.
-- Sign in requires verified email (expected: block unverified).
-- Inactive accounts are blocked.
-- Session refresh path works (`/api/auth/session`).
-- Protected routes redirect correctly when unauthenticated.
-- Admin/staff routes enforce role boundaries.
+## UI / editor / onboarding
 
----
+- [ ] Existing editor/portal tokens and reusable components are used.
+- [ ] Desktop/mobile, dark/light and relevant EN/PL flows are checked in a browser.
+- [ ] Focus, keyboard controls, dialogs and overflow work.
+- [ ] Failed saves block advancement and preserve the current inputs.
+- [ ] Pausing/resuming, import and explicit publication consent work if touched.
+- [ ] Admin test drafts remain isolated from real Master CV/profile/languages.
+- [ ] Shared shell/navigation works after leaving the changed screen.
 
-## Checklist: Supabase / RLS / RPC changes
+## Public CV / SEO
 
-- Migration is a new file (no editing of previously applied migrations for prod-like envs).
-- RLS is not weakened; policies are least-privilege.
-- `security definer` functions are justified, minimal, and have safe `search_path`.
-- RPC functions validate inputs and enforce roles.
-- Rollback guidance exists (new rollback migration if needed).
-- Impact on existing data is documented.
-
----
-
-## Checklist: YAML contract / i18n changes
-
-- EN/PL keys and section ordering stay aligned.
-- `data/public/locales.yaml` remains valid and points to existing files.
-- Legacy renderer (`scripts/main.js` + `scripts/public-resume.js`) renders both locales correctly.
-- If Next renderer consumes the YAML too, parity expectations are documented.
-- Contract tests updated (`scripts/phase-b/resume-yaml-contract.js` and/or `tests/`).
-
----
-
-## Checklist: Public resume / SEO (Phase E)
-
-- `/r/[slug]` handles:
-  - active slug -> renders
-  - missing slug -> 404
-  - inactive slug -> 404 or explicit “unavailable”
-- `allow_indexing` drives robots meta and any headers as designed.
-- Canonical URL is correct.
-- Structured data (if added) is valid and stable.
-- Sitemap/robots strategy is documented.
+- [ ] Active `/{personSlug}/{publicId}` links render their selected snapshot data.
+- [ ] Missing/inactive links do not expose CV content.
+- [ ] Unpublish, republish and publication retries behave consistently.
+- [ ] Indexing controls, canonical URLs and locale selection remain correct.
+- [ ] Public export and rendering never fall back to private live Master CV data.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# OpenCiVera — project instructions for Codex
+
+## Working agreement
+
+- Respond in Polish unless the user asks otherwise. Keep identifiers consistent with existing code.
+- Deliver the requested change through implementation and validation; make routine, reversible decisions independently.
+- Prefer KISS, DRY and readable TypeScript: reuse existing components and domain functions before adding abstractions or dependencies.
+- Prioritize data integrity and security, then correctness, maintainability, performance and delivery speed.
+- Inspect the working tree before editing. Preserve existing changes and running development servers.
+- Follow the current [Git workflow](docs/guides/development/git-workflow.md); do not duplicate its naming rules here or invent issue/PR numbers.
+- Report what changed, what was checked, unresolved limitations and whether work is local, pushed or deployed. Code completion does not imply deployment.
+
+## Start with the relevant context
+
+- Read [README](README.md) for setup and [project brief](.codex/project-brief.md) for the domain.
+- Use the [code map](.codex/site-map-and-dependencies.md) to locate the affected modules.
+- Consult only the relevant [guides](docs/guides/README.md), [ADRs](docs/adr/README.md) and feature documentation.
+- Treat [project status](docs/STATUS.md) as dated planning context, not proof that a change is deployed.
+- Verify architecture claims against current code, tests and migration history. Report and correct stale documentation within the task scope; do not restore retired behavior just because an old document describes it.
+
+## Current architecture and contracts
+
+- The active application is Next.js App Router, React and TypeScript under `app/`; route handlers live under `app/api/`.
+- `public/` contains static assets, YAML and vendor/runtime or migration helpers. The former static HTML application is retired.
+- `netlify.toml` is the deployment configuration; it currently contains build/plugin settings, not legacy HTML redirects.
+- Supabase owns authentication, RBAC, persistence, publication and audit records. Keep ownership checks in APIs and database policies/RPCs.
+- `resume_documents` stores private editable Master CV YAML; `resume_revisions` stores its revision history.
+- `resume_presets` and `resume_preset_variants` select saved CV content. `resume_published_cvs` and `resume_published_cv_locales` store immutable publication snapshots; `resume_public_links` controls their public identity and active state.
+- Public CVs use `/{personSlug}/{publicId}` and the snapshot resolver. Never expose unselected Master CV data or substitute live document content for a publication snapshot.
+- Preserve YAML/API contracts, document language behavior, EN/PL labels and existing fallbacks. Test ordinary editing, import and public export when their shared code changes.
+- Normal onboarding writes the user's Master CV. Admin onboarding tests use separate drafts and must not change the real Master CV, profile or account languages.
+
+## Auth, data and migrations
+
+- Preserve `admin`, `manager`, `user` and `recruiter` boundaries, account activity and verification checks.
+- Capability inheritance does not grant access to another user's private CV. Exact-role checks and capability checks are different; use the existing RBAC helpers appropriately.
+- Never weaken RLS or expand privileged access implicitly. Preserve audit requirements for privileged operations.
+- Add migrations for schema/RLS/RPC changes; do not rewrite migrations already applied to shared environments.
+- Keep `security definer` functions narrowly scoped, with explicit actor/input checks and safe `search_path`.
+- Keep secrets in existing environment/config mechanisms. Do not print credentials or commit tokens.
+- Distinguish an authorized local implementation from applying migrations or deploying to a named environment; use the user's stated scope and deployment instructions.
+
+## UI and design
+
+- Use the existing editor as the current visual reference: [editor implementation](app/master-resume/editor-canvas-client.tsx) and [shared styles](app/globals.css).
+- Reuse editor `--ed-*` tokens and the existing portal theme tokens in their respective surfaces. Do not introduce a parallel palette or replace the styling system incidentally.
+- Reuse forms, validation, import review and rendering components. Keep product copy free of implementation details unless users need them to decide.
+- Maintain keyboard access, visible focus, responsive layout and both supported themes. Verify layout changes in a real browser.
+
+## TDD and definition of done
+
+- For behavior changes and bug fixes, first write a meaningful failing regression test, then implement the smallest fix and refactor with the test passing.
+- Test observable behavior, role/data boundaries and error/retry paths. Do not substitute source-text assertions for behavioral tests when the behavior can be exercised.
+- For visual behavior, reproduce the failing browser check before changing the UI and recheck the result. Do not add artificial unit tests for copy-only or styling-only edits.
+- Run the smallest relevant check during implementation. Before finishing code changes, run `npm.cmd run verify` (lint, typecheck, tests).
+- For documentation-only changes, verify links and commands; run `npm.cmd test` when changing development/testing workflows. State any skipped checks and why.
+- For UI changes, check desktop/mobile, EN/PL where relevant, keyboard focus and dark/light themes. For auth, publication or database changes, exercise the relevant role boundaries and save/publish/retry paths.
+- Identify mocked/isolated validation explicitly; do not report it as a real Supabase staging or production check.
+- Update affected guides, contracts and manual scenarios with behavior changes. See the [validation runbook](.codex/runbooks/testing-and-validation.md) and [task checklists](.codex/task-checklists.md).
+
+## Instruction maintenance
+
+- Keep this file as the canonical project instruction entry point. Detailed procedures belong in the linked documents.
+- `.codex/instructions.md` is a compatibility pointer, not a second copy of these rules.
+- `CLAUDE.md` and `.claude/` are maintained separately; do not edit them as part of Codex configuration maintenance unless the user explicitly includes them.
+- Do not add mandatory skills, agents, approval steps or tools that the environment does not provide. Use delegation only when authorized and useful for independent work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # OpenCiVera/OpenCVHub Claude Configuration
 
-**Last Updated:** July 2026  
+**Last Updated:** 2026-09-08  
 **Phase Tracking:** See [docs/STATUS.md](docs/STATUS.md) for current phase, status, and roadmap  
 **Stack:** Next.js (App Router) + React + TypeScript + Supabase + Tailwind CSS
 
@@ -48,6 +48,8 @@ OpenCiVera/
 │   ├── admin/             # Admin panel (RBAC-gated, protected)
 │   ├── master-resume/     # Editor canvas (Phase D, protected)
 │   ├── user/              # Personal Hub (protected)
+│   ├── onboarding/        # First-use "guided first CV" flow (protected, see Implementation Notes)
+│   ├── settings/          # Admin onboarding-test harness (protected, admin-only)
 │   ├── docs/              # In-app docs site (Tutorials / Test Scenarios, ADR 0020)
 │   ├── [personSlug]/      # Public CV route: /{person-slug}/{public-id}
 │   ├── resume/            # Public sample CV
@@ -74,7 +76,7 @@ Key files NOT to edit (read-only):
 - supabase/migrations/     (ask Backend Engineer)
 ```
 
-Protected routes have no `(authenticated)` route group — `dashboard/`, `admin/`, `master-resume/`, `user/` are plain top-level segments, each independently gated by `requireRequestActor()`.
+Protected routes have no `(authenticated)` route group — `dashboard/`, `admin/`, `master-resume/`, `user/`, `onboarding/`, `settings/` are plain top-level segments, each independently gated by `requireRequestActor()`.
 
 ---
 
@@ -159,6 +161,7 @@ Master Resume (Draft) ──publish──> Saved Version (Snapshot)
 - Zainstalowany globalnie: `npm install -g supabase`
 - Use: `supabase db push` (push local migrations)
 - Use: `supabase pull` (pull schema z production)
+- **Known issue (as of 2026-09-07):** the migration ledger on `test`/`prod` has drifted from local `.sql` filenames — some migrations were applied directly (e.g. via an MCP `apply_migration` call) rather than via `db push`, and `test` has at least one orphan migration with no local file. `supabase db push` in this state is likely to fail on conflicts/duplicate objects. Prefer applying new migrations directly via `mcp__supabase-test__apply_migration` / `mcp__supabase-prod__apply_migration` (same SQL, same name on both) until the ledger is repaired.
 
 **NEVER DO:**
 - Hardcode secrets (use env vars only)
@@ -353,6 +356,7 @@ node tests/phase-d-editor-implementation.test.js
 | **Editor** | `app/master-resume/**` | Publish, rollback, draft save/restore |
 | **Public View** | `app/[person-slug]/[public-id]/` | Canonical route renders, indexing controls |
 | **Admin RBAC** | `app/admin/`, `app/api/admin/**` | Role hierarchy enforced, user deletion respects boundaries |
+| **Onboarding** | `app/onboarding/**`, `app/api/resume/onboarding`, `app/lib/resume-onboarding*.ts` | Enrollment/resumption states, selection is raw-domain (see Implementation Notes), publish creates exactly one CV |
 
 ### Testing Discipline (From .codex/instructions.md)
 
@@ -456,6 +460,27 @@ See [ADR 0014](docs/adr/0014-pdf-rendering-architecture.md).
 
 **ATS Export Refactor:** Export rules/constants and Phase K scoring types are isolated in `app/lib/ats-export-rules.ts`; `convertResumeToPlainText`/`convertResumeToAtsYaml`/`getRawYamlSource` consume them. ATS Ready dropdown (CVasCode / .txt / .yaml) downloads the currently selected language version. Foundation for Phase K — see [Phase K ATS Intelligence](docs/phases/phase-k-ats-intelligence-plan.md).
 
+**CV Import (PDF/DOCX/YAML/TXT):** `app/lib/resume-import/` (`parse-resume-file.ts`,
+`extract-text.ts`, `parse-plain-text.ts`, `parse-yaml-cv.ts`, `text-blocks.ts`,
+`merge-imported-resume.ts`, `read-upload.ts`) is a heuristic, best-effort
+extractor — never guaranteed correct, so nothing it produces touches the
+draft until the user reviews and confirms it. `POST /api/resume/import-file`
+parses the upload; `ImportCvBanner` (`app/master-resume/import-cv-banner.tsx`)
+is the upload trigger and `ImportReviewModal`
+(`app/master-resume/import-review-modal.tsx`) is the confirmation step —
+both take an optional `language` prop (`"en" | "pl"`) so they can render in
+the onboarding guide's language, not just English. Import is **additive,
+never destructive**: `mergeImportedResume()` adds selected entries to the
+existing draft, it does not overwrite sections. If the parsed name differs
+from the draft's current name, the modal blocks adding content until the
+user explicitly acknowledges the mismatch (avoids silently mixing two
+people's CVs into one document). Test contracts:
+`tests/resume-import-file-route-contract.test.mjs`,
+`tests/resume-import-merge.test.mjs`, `tests/resume-import-plain-text.test.mjs`,
+`tests/resume-import-text-blocks.test.mjs`, `tests/resume-import-upload.test.mjs`,
+`tests/resume-import-yaml.test.mjs`, `tests/import-review-name-mismatch.test.mjs`,
+`tests/import-review-selection.test.mjs`.
+
 **Published Export Selection Contract (R09):** `fetchPublishedResumeExportByPublicLink`
 (`app/lib/resume-server.ts`) is the single resolver behind every published-CV
 export surface (PDF, ATS `.txt`, ATS `.yaml`, CVasCode, public OpenCV API v1).
@@ -486,12 +511,21 @@ means no ATS transformations, not unselected master content. Contract tests
 execute `buildPublishedExportContent` directly:
 `tests/resume-export-contract.test.mjs`,
 `tests/adr-0008-opencv-public-api-contract.test.mjs`.
+**This contract has already been violated twice by new code that computed a
+selection against a normalized document instead of the raw one** (most
+recently `firstCvSelection` in `app/lib/resume-onboarding.ts`, fixed
+2026-09-07 — it now probes raw items via `normalizeResumeDocument` per-item
+rather than filtering an already-normalized array, so indexes still line up
+with the raw YAML the selection is later applied to). Any function that
+builds a `ResumePresetSelection` must be checked against this rule, not just
+functions that consume one.
 
 **API Routes (Public CV / Export):**
 - GET/POST `/api/resume/document?locale=en|pl` — Fetch/save documents
 - POST `/api/resume/publish` — Create revision snapshot
 - POST `/api/resume/rollback` — Restore previous version
 - GET|POST|PATCH `/api/resume/languages` — Language management
+- POST `/api/resume/import-file` — Parse an uploaded PDF/DOCX/YAML/TXT CV for review (never saves directly)
 - GET `/api/resume/presets` — List Saved Versions
 - POST/PATCH `/api/resume/presets/[id]/publish` — Publish version
 - POST `/api/resume/presets/[id]/unpublish` — Unpublish version
@@ -500,6 +534,12 @@ execute `buildPublishedExportContent` directly:
 - GET `/api/resume/export/cvac` — Raw CVasCode source YAML export
 - GET `/api/resume/export/pdf` — Published CV PDF export
 - POST `/api/resume/export/pdf/preview` — Draft CV PDF export (admin, gated by `pdf_draft_enabled` flag)
+
+**API Routes (Onboarding):**
+- PATCH `/api/resume/onboarding` — Save guide progress (no owner/preset ID accepted from client)
+- POST `/api/resume/onboarding` — Complete the guide with an explicit boolean `publish` choice
+- GET/PATCH `/api/admin/onboarding-test/[runId]` — Admin-only onboarding QA harness: read/save an isolated test draft
+- POST `/api/admin/onboarding-test/[runId]` — Finish an onboarding test run (publish or not)
 
 **Routing Model:**
 - **Canonical:** `/{person-slug}/{public-id}` (primary, from `resume_public_links`), the only public route
@@ -770,6 +810,50 @@ What's actually true as of 2026-08-26:
   was corrected — faster and can't drift from reality the way a static
   checklist can.
 
+**First-Use Master CV Onboarding:** `/onboarding` walks a newly registered
+account through welcome → scratch/import choice → the eleven Master Resume
+sections → preview → an explicit publish choice, reusing `EditorCanvasClient`
+and the CV Import review flow above. Migration
+`20260907000000_resume_onboarding.sql` adds `resume_onboarding`
+(one row per account, RLS-scoped to its own owner) and enrolls only profiles
+created **after** the migration — existing accounts get no row and never see
+the guide (by design, not a gap). States: `pending` (dashboard/master-resume
+redirect to `/onboarding`) → `active` → `paused` (progress saved, resumable
+from the dashboard) → `completed` (route returns to dashboard, cannot be
+reset through authenticated updates). `PATCH /api/resume/onboarding` saves
+progress and accepts no owner/preset ID from the client; `POST
+/api/resume/onboarding` requires an explicit boolean `publish` choice.
+Publishing derives the selection **from the raw saved YAML** — see the
+"this contract has already been violated twice" note under Published Export
+Selection Contract above; `firstCvSelection()`
+(`app/lib/resume-onboarding.ts`) is the function responsible for getting
+this right. `reserve_onboarding_preset` (SECURITY INVOKER) locks the
+onboarding row and reserves exactly one CV version so retries are
+idempotent; it delegates to the existing `publishResumePreset` for variants,
+snapshots, audit records and the canonical public link (published locale
+only, indexing disabled). Full behavioral spec:
+[docs/guides/features/first-use-master-cv.md](docs/guides/features/first-use-master-cv.md).
+Test contracts: `tests/resume-onboarding.test.mjs`,
+`tests/onboarding-progress.test.mjs`.
+
+**Admin Onboarding-Test Harness:** `/settings` (admin-only) and migration
+`20260907010000_admin_onboarding_tests.sql` let staff dry-run the onboarding
+guide without touching their own Master Resume or account state. Test runs
+live in `resume_onboarding_test_runs`, not `resume_onboarding`; synthetic
+presets/published CVs created by a test run are tagged via a nullable
+`resume_presets.onboarding_test_run_id` FK rather than a separate table —
+**every new `resume_presets` code path must decide whether it should
+include or exclude onboarding-test rows** (dashboard, publish, export, and
+the transfer/export route already do). RPCs `configure_onboarding_test`,
+`save_onboarding_test`, `finish_onboarding_test` are `SECURITY DEFINER`,
+gated by `require_onboarding_test_admin()` (active, verified admin only);
+`guard_onboarding_test_preset()` blocks `authenticated`/`anon` from
+inserting or updating a preset's `onboarding_test_run_id` directly through
+PostgREST. `POST/PATCH /api/admin/onboarding-test/[runId]` must call
+`flagSuspiciousResumeContent()` on saved test YAML like every other
+YAML-content save path (draft, publish, transfer/import) — this was missing
+until fixed 2026-09-07. Test contract: `tests/admin-onboarding-test.test.mjs`.
+
 ---
 
 ## ✅ Pre-Commit Checklist
@@ -847,5 +931,5 @@ Before pushing code:
 ---
 
 **Status:** Production-ready (merged with .codex/instructions.md)  
-**Last Review:** July 2026  
+**Last Review:** 2026-09-08  
 **Next Update:** See [docs/STATUS.md](docs/STATUS.md) for current phase and next milestones

--- a/app/components/app-brand.tsx
+++ b/app/components/app-brand.tsx
@@ -1,38 +1,48 @@
-import Link from "next/link";
-import type { ReactNode } from "react";
+"use client";
 
-const defaultLogo = (
-  <svg width="56" height="56" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <g transform="translate(40, 40)">
-      <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" fill="url(#ocv-brand-grad)" opacity="0.15" />
-      <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" stroke="url(#ocv-brand-grad)" strokeWidth="2.5" fill="none" />
-      <circle cx="0" cy="0" r="8" stroke="#5E6AD2" strokeWidth="2" fill="none" />
-      <circle cx="0" cy="0" r="3.5" fill="#009c8a" />
-      <circle cx="0" cy="-15" r="1.8" fill="#6872D9" />
-      <circle cx="13" cy="7.5" r="1.8" fill="#6872D9" />
-      <circle cx="-13" cy="7.5" r="1.8" fill="#6872D9" />
-    </g>
-    <defs>
-      <linearGradient id="ocv-brand-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stopColor="#5E6AD2" />
-        <stop offset="50%" stopColor="#6872D9" />
-        <stop offset="100%" stopColor="#009c8a" />
-      </linearGradient>
-    </defs>
-  </svg>
-);
+import Link from "next/link";
+import { useId, type ReactNode } from "react";
+
+function BrandLogo() {
+  const gradientId = useId();
+  return (
+    <svg width="56" height="56" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <g transform="translate(40, 40)">
+        <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" fill={`url(#${gradientId})`} opacity="0.15" />
+        <polygon points="0,-20 17.32,-10 17.32,10 0,20 -17.32,10 -17.32,-10" stroke={`url(#${gradientId})`} strokeWidth="2.5" fill="none" />
+        <circle cx="0" cy="0" r="8" stroke="#5E6AD2" strokeWidth="2" fill="none" />
+        <circle cx="0" cy="0" r="3.5" fill="#009c8a" />
+        <circle cx="0" cy="-15" r="1.8" fill="#6872D9" />
+        <circle cx="13" cy="7.5" r="1.8" fill="#6872D9" />
+        <circle cx="-13" cy="7.5" r="1.8" fill="#6872D9" />
+      </g>
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#5E6AD2" />
+          <stop offset="50%" stopColor="#6872D9" />
+          <stop offset="100%" stopColor="#009c8a" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
 
 type Props = {
-  href?: string;
+  href?: string | null;
   logo?: ReactNode;
   name?: string;
 };
 
-export default function AppBrand({ href = "/", logo = defaultLogo, name = "OpenCiVera" }: Props) {
-  return (
-    <Link className="app-brand" href={href} aria-label={name}>
+export default function AppBrand({ href = "/", logo = <BrandLogo />, name = "OpenCiVera" }: Props) {
+  const content = (
+    <>
       {logo ? <span className="app-brand__logo" aria-hidden>{logo}</span> : null}
       <span className="app-brand__name">{name}</span>
-    </Link>
+    </>
+  );
+  return href === null ? (
+    <div className="app-brand" aria-label={name}>{content}</div>
+  ) : (
+    <Link className="app-brand" href={href} aria-label={name}>{content}</Link>
   );
 }

--- a/app/onboarding/onboarding-client.tsx
+++ b/app/onboarding/onboarding-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import AppBrand from "../components/app-brand";
+import OnboardingProgress from "./onboarding-progress";
 import {
   ONBOARDING_PUBLISH_STEP,
   ONBOARDING_REVIEW_STEP,
@@ -85,10 +86,9 @@ export default function OnboardingClient(props: Props) {
   const t = (en: string, pl: string) => (uiLanguage === "pl" ? pl : en);
   const disabled = busy || props.loading || props.importing || props.loadError;
   const section = ONBOARDING_SECTIONS[step - 2];
-  const percent = finished ? 100 : Math.round((step / (ONBOARDING_PUBLISH_STEP + 1)) * 100);
 
   useEffect(() => {
-    heading.current?.focus();
+    heading.current?.focus({ preventScroll: true });
   }, [step, finished]);
 
   async function progress(nextStep: number, status: "active" | "paused" = "active") {
@@ -171,24 +171,23 @@ export default function OnboardingClient(props: Props) {
   }
 
   return (
-    <section className="resume-editor-shell onboarding" lang={uiLanguage}>
-      <div className="onboarding__progress">
-        <div className="onboarding__progress-label">
-          <span>{t("Your first CV", "Twoje pierwsze CV")}</span>
-          <span>
-            {finished ? t("Complete", "Gotowe") : `${step + 1} / ${ONBOARDING_PUBLISH_STEP + 1}`} ·{" "}
-            {percent}%
-          </span>
-        </div>
-        <progress
-          value={percent}
-          max={100}
-          aria-label={t("Guide progress", "Postęp przewodnika")}
+    <section className="resume-editor-shell onboarding" lang={uiLanguage} aria-labelledby="onboarding-title">
+      <aside className="onboarding__sidebar">
+        <AppBrand href={null} />
+        <OnboardingProgress
+          steps={TITLES[uiLanguage]}
+          step={step}
+          finished={finished}
+          label={t("Guide progress", "Postęp przewodnika")}
+          completeLabel={t("Complete", "Gotowe")}
         />
-      </div>
+      </aside>
       <div className="onboarding__card" aria-busy={busy}>
         <div className="onboarding__topline">
-            <AppBrand href={props.testRunId ? `/onboarding?test=${props.testRunId}` : "/onboarding"} />
+          <span className="onboarding__step-count">
+            {t("Your first CV", "Twoje pierwsze CV")}
+            <strong>{finished ? t("Complete", "Gotowe") : `${step + 1} / ${TITLES[uiLanguage].length}`}</strong>
+          </span>
           <label className="onboarding__language">
             {t("Guide language", "Język przewodnika")}
             <select
@@ -202,7 +201,7 @@ export default function OnboardingClient(props: Props) {
             </select>
           </label>
         </div>
-        <h1 ref={heading} tabIndex={-1}>
+        <h1 id="onboarding-title" ref={heading} tabIndex={-1}>
           {finished
             ? publicPath
               ? t("Your CV is ready to send", "Twoje CV jest gotowe do wysłania")

--- a/app/onboarding/onboarding-progress.tsx
+++ b/app/onboarding/onboarding-progress.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Props = {
+  steps: readonly string[];
+  step: number;
+  finished: boolean;
+  label: string;
+  completeLabel: string;
+};
+
+export default function OnboardingProgress({ steps, step, finished, label, completeLabel }: Props) {
+  const current = useRef<HTMLLIElement>(null);
+  const percent = finished ? 100 : Math.round((step / steps.length) * 100);
+
+  useEffect(() => {
+    const showCurrentStep = () => current.current?.scrollIntoView({ block: "nearest", behavior: "instant" });
+    showCurrentStep();
+    window.addEventListener("resize", showCurrentStep);
+    return () => window.removeEventListener("resize", showCurrentStep);
+  }, [step, steps]);
+
+  return (
+    <div className="onboarding__progress">
+      <div className="onboarding__progress-label">
+        <span>{finished ? completeLabel : label}</span>
+        <strong>{percent}%</strong>
+      </div>
+      <progress className="sr-only" value={percent} max={100} aria-label={label} />
+      <ol className="onboarding__steps" aria-label={label}>
+        {steps.map((title, index) => {
+          const active = !finished && index === step;
+          const state = finished || index < step ? "complete" : active ? "current" : "upcoming";
+          return (
+            <li key={title} data-state={state} aria-current={active ? "step" : undefined} ref={active ? current : undefined}>
+              <span className="onboarding__step-number" aria-hidden="true">{index + 1}</span>
+              <span className="onboarding__step-title">{title}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/app/onboarding/onboarding.css
+++ b/app/onboarding/onboarding.css
@@ -1,61 +1,146 @@
+/* Route-scoped, like the editor's wide-shell mode; also removes hidden navigation
+   from keyboard focus without changing the shared layout or modal stacking. */
+.app-header:has(~ .app-main .onboarding) {
+  display: none;
+}
+.app-main:has(.onboarding) {
+  width: 100%;
+  padding: 0;
+}
 .onboarding {
-  max-width: 920px;
-  margin: 0 auto;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 0;
+  min-height: 100dvh;
+  background: var(--ed-work);
   color: var(--ed-t1);
 }
-.onboarding__progress {
+.onboarding__sidebar {
   position: sticky;
-  top: var(--app-header-height, 56px);
-  z-index: 20;
-  padding: 1rem 1.5rem;
-  background: var(--ed-work);
-  border-bottom: 1px solid var(--ed-line);
+  top: 0;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1rem;
+  border-right: 1px solid var(--ed-line);
+  background: var(--ed-nav-bg);
+  min-height: 0;
+}
+.onboarding__sidebar .app-brand {
+  flex-shrink: 0;
+  margin-bottom: 1.5rem;
+}
+.onboarding__sidebar .app-brand__name {
+  font-size: 1.05rem;
+}
+.onboarding__progress {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 .onboarding__progress-label {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
-  font-size: 0.9rem;
-  margin-bottom: 0.5rem;
+  padding: 0 0.5rem 1rem;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ed-t2);
 }
-.onboarding progress {
-  display: block;
-  width: 100%;
-  height: 6px;
-  border: 0;
-  border-radius: 3px;
-  overflow: hidden;
-  background: var(--ed-raised);
-  accent-color: var(--ed-accent);
+.onboarding__progress-label strong {
+  color: var(--ed-t1);
+  font-variant-numeric: tabular-nums;
 }
-.onboarding progress::-webkit-progress-bar {
-  background: var(--ed-raised);
+.onboarding__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.25rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
 }
-.onboarding progress::-webkit-progress-value {
+.onboarding__steps li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  align-items: center;
+  min-height: 38px;
+  gap: 0.5rem;
+  color: var(--ed-t2);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+.onboarding__steps li:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: 25px;
+  top: 50%;
+  bottom: -50%;
+  width: 1px;
+  background: var(--ed-line-2);
+}
+.onboarding__steps li[data-state="complete"]::after {
   background: var(--ed-accent);
 }
-.onboarding progress::-moz-progress-bar {
+.onboarding__step-number {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  justify-self: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--ed-line-2);
+  border-radius: 50%;
+  background: var(--ed-nav-bg);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+.onboarding__steps li[data-state="complete"] .onboarding__step-number {
+  color: var(--ed-accent);
+  border-color: var(--ed-accent);
+}
+.onboarding__steps li[aria-current="step"] {
+  min-height: 68px;
+  color: var(--ed-t1);
+  font-weight: 600;
+}
+.onboarding__steps li[aria-current="step"] .onboarding__step-number {
+  width: 48px;
+  height: 48px;
+  font-size: 1.5rem;
+  color: white;
+  border-color: var(--ed-accent);
   background: var(--ed-accent);
+  box-shadow: 0 0 0 4px var(--ed-accent-bg);
 }
 .onboarding__card {
-  background: var(--ed-work);
-  padding: clamp(1rem, 4vw, 3rem);
-  border: 1px solid var(--ed-line);
-  border-radius: 12px;
+  width: 100%;
+  max-width: 880px;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 2rem clamp(1.5rem, 5vw, 4rem) 3rem;
 }
 .onboarding__topline {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 2.5rem;
+  margin-bottom: clamp(2rem, 6vh, 4rem);
 }
-.onboarding__topline .app-brand__name {
-  font-size: 1.15rem;
+.onboarding__step-count {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--ed-t2);
+}
+.onboarding__step-count strong {
+  color: var(--ed-t1);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
 }
 .onboarding h1 {
-  font-family: var(--font-display);
-  font-size: clamp(1.8rem, 4vw, 2.75rem);
+  font-family: var(--font-body);
+  font-size: clamp(1.65rem, 3vw, 2.5rem);
+  font-weight: 600;
   line-height: 1.15;
   letter-spacing: -0.03em;
   margin-bottom: 1.25rem;
@@ -96,7 +181,7 @@
   background: var(--ed-card);
   color: var(--ed-t1);
   border: 1px solid var(--ed-line-2);
-  border-radius: 6px;
+  border-radius: var(--ed-radius);
   padding: 0.65rem;
   max-width: 100%;
 }
@@ -116,7 +201,7 @@
   padding: 1.4rem;
   margin-bottom: 0.8rem;
   border: 1px solid var(--ed-line-2);
-  border-radius: 8px;
+  border-radius: var(--ed-radius);
   cursor: pointer;
 }
 .onboarding__choice:has(input:checked) {
@@ -178,10 +263,78 @@
   overflow: auto;
   border-radius: 8px;
 }
+@media (max-width: 900px) {
+  .onboarding {
+    grid-template-columns: 224px minmax(0, 1fr);
+  }
+  .onboarding__card {
+    padding-inline: 1.5rem;
+  }
+  .onboarding__form .resume-human-editor__grid,
+  .onboarding__form .resume-human-editor__row {
+    grid-template-columns: 1fr;
+  }
+}
 @media (max-width: 600px) {
+  .onboarding {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+  .onboarding__sidebar {
+    padding: 0.5rem 0;
+  }
+  .onboarding__sidebar .app-brand {
+    justify-content: center;
+    margin: 0 0 0.5rem;
+    gap: 0;
+  }
+  .onboarding__sidebar .app-brand__name,
+  .onboarding__progress-label > span {
+    display: none;
+  }
+  .onboarding__step-title {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+  .onboarding__progress-label {
+    justify-content: center;
+    padding: 0 0 0.5rem;
+    font-size: 0.65rem;
+  }
+  .onboarding__steps {
+    padding: 0;
+  }
+  .onboarding__steps li {
+    grid-template-columns: 55px;
+    min-height: 32px;
+    gap: 0;
+  }
+  .onboarding__steps li:not(:last-child)::after {
+    left: 27px;
+  }
+  .onboarding__step-number {
+    width: 22px;
+    height: 22px;
+    font-size: 0.65rem;
+  }
+  .onboarding__steps li[aria-current="step"] {
+    min-height: 54px;
+  }
+  .onboarding__steps li[aria-current="step"] .onboarding__step-number {
+    width: 36px;
+    height: 36px;
+    font-size: 1.2rem;
+  }
+  .onboarding__card {
+    padding: 1rem 1rem 2rem;
+  }
   .onboarding__topline {
     align-items: flex-start;
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 1rem;
     margin-bottom: 2rem;
   }
@@ -194,7 +347,11 @@
     width: 100%;
     white-space: normal;
   }
-  .onboarding__progress {
-    padding: 0.75rem 1rem;
+  .onboarding__language {
+    font-size: 0.75rem;
+  }
+  .onboarding__choice {
+    padding: 1rem;
+    gap: 0.65rem;
   }
 }

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,7 +11,8 @@ For setting up a local environment or understanding code patterns.
 - [Local Development Setup](development/local-development.md) — Prerequisites, database setup, running tests
 - [Environment Matrix](development/environment-matrix.md) — Env vars across preview/production
 - [Responsive UI & Drawer Patterns](development/responsive-ui-and-drawer-patterns.md) — UI component patterns
-- [Codex Instructions](../../.codex/instructions.md) — AI-assisted development workflow and team discipline
+- [Project Agent Instructions](../../AGENTS.md) — Codex working agreements and contract boundaries
+- [Codex Setup](development/codex-setup.md) — Instruction discovery, configuration and maintenance
 
 ---
 

--- a/docs/guides/development/codex-setup.md
+++ b/docs/guides/development/codex-setup.md
@@ -1,0 +1,72 @@
+# Codex setup for OpenCiVera
+
+The repository's canonical Codex instructions are in [AGENTS.md](../../../AGENTS.md).
+This setup keeps project facts, working rules and tool configuration separate.
+`CLAUDE.md` is maintained independently and is not changed by this setup.
+
+## Where context lives
+
+| File | Purpose |
+| --- | --- |
+| [AGENTS.md](../../../AGENTS.md) | Project rules, TDD, validation, communication and contract boundaries |
+| [Project brief](../../../.codex/project-brief.md) | Short product/domain orientation |
+| [Code map](../../../.codex/site-map-and-dependencies.md) | Routes, modules and dependencies |
+| [Validation runbook](../../../.codex/runbooks/testing-and-validation.md) | Test commands and browser checks |
+| [Git workflow](git-workflow.md) | Current branch, commit and PR conventions |
+| [Guides](../README.md) and [ADRs](../../adr/README.md) | Feature behavior, policies and architectural decisions |
+| [Project status](../../STATUS.md) | Dated roadmap and progress; verify deployment separately |
+| [Project config](../../../.codex/config.toml) | Existing agent limits and Netlify MCP settings |
+
+## Starting a session
+
+1. Open this repository as the working project, rather than its parent directory.
+2. Trust the repository in Codex if appropriate: project-local `.codex/` configuration
+   layers are loaded only for trusted projects.
+3. Start a fresh session after changing startup instructions. Ask:
+   “Wymień wczytane instrukcje projektu i podsumuj wymagane testy”.
+4. Expect the root `AGENTS.md`, its project agreements and relevant linked procedures
+   to be recognized. Merely listing a documentation link does not automatically
+   inject the entire linked document; the agent reads it when the task needs it.
+
+Codex discovers global instructions in its home directory (normally `~/.codex`)
+and project instructions from the project root toward the working directory.
+Within a directory, `AGENTS.override.md` takes precedence over `AGENTS.md`, followed
+by configured fallback names; at most one is selected per directory. See the
+[official AGENTS.md guide](https://learn.chatgpt.com/docs/agent-configuration/agents-md).
+
+No `CLAUDE.md` fallback is needed here because the root `AGENTS.md` exists.
+Keep global `~/.codex/AGENTS.md` for optional personal preferences across repositories;
+this project setup does not edit global configuration or instructions.
+
+## Tool configuration
+
+User defaults belong in `~/.codex/config.toml`; repository-specific settings belong
+in `.codex/config.toml`. Session settings and higher-priority policy can affect the
+effective configuration. See [official configuration guidance](https://learn.chatgpt.com/docs/config-file/config-basic).
+
+The repository keeps its existing agent limits, agent models and Netlify MCP definition.
+The existing role profiles under `.codex/agents/` refer to the root instructions,
+work only within their assigned scope, and do not require a shared `state.yaml`.
+The limits do not require spawning agents. MCP credentials are supplied through the
+existing environment-variable mechanism, not checked into configuration.
+No model, permission mode, global trust setting or production deployment target
+is changed by this documentation setup.
+
+## Task prompt
+
+Use the [task template](../../../.codex/prompt-templates.md). Include the desired
+behavior, affected route, acceptance criteria and whether the result should stay
+local or be deployed. For UI, name the existing visual reference. For persistence,
+state whose data may change. The agent should resolve routine implementation
+choices within that scope.
+
+## Keeping instructions accurate
+
+- Keep the root rules short; link specialized procedures instead of copying them.
+- Update the code map when routes or ownership boundaries change.
+- Record architectural decisions in ADRs and user-facing behavior in feature guides.
+- Use current code, tests and migration history to reconcile stale descriptions.
+- Check relative Markdown links after moving documents.
+- Do not use historical `.html` routes or retired scripts as current QA targets.
+- Add nested `AGENTS.md` files only when a subdirectory needs genuinely distinct
+  rules; retain the root file as the starting point.

--- a/docs/guides/development/git-workflow.md
+++ b/docs/guides/development/git-workflow.md
@@ -11,31 +11,32 @@ This file is the canonical source for the OpenCiVera git workflow convention —
 
 ## Branch naming
 
-Use a conventional prefix + short kebab-case description:
-- `feat/<area>-<change>` (new functionality)
-- `fix/<area>-<bug>` (bug fix)
-- `refactor/<area>-<change>` (no behavior change intended)
-- `docs/<topic>` (documentation-only)
-- `chore/<topic>` (tooling/cleanup)
+Use: `ocv-<numer>-<krótki-opis-kebab-case>`
+
+- `<numer>` — numer powiązanego PR/issue z GitHuba, zero-padded do 4 cyfr (np. `0150`). Ponieważ GitHub nadaje numer PR-a dopiero przy jego utworzeniu, w praktyce najpierw zakłada się issue (i używa jego numeru) albo tworzy się PR wcześnie (np. jako draft) i w razie potrzeby zmienia nazwę brancha.
+- `<krótki-opis-kebab-case>` — zwięzły opis treści brancha, bez prefiksu typu zmiany (ten trafia do commitów/PR-ów, patrz niżej).
 
 Examples:
-- `feat/public-resume-seo`
-- `fix/auth-session-refresh`
-- `docs/codex-git-workflow`
+- `ocv-0150-import-cv-z-pliku`
+- `ocv-0151-auth-session-refresh`
 
-## Commit messages
+Ten format zastąpił poprzednią konwencję `<prefix>/<area>-<change>` (feat/fix/refactor/docs/chore jako prefiks brancha) — historyczne branche i przykłady z nią mogą jeszcze występować w starszych PR-ach/dokumentach.
 
-Use Conventional Commits (imperative, present tense):
-- `feat: <what>`
-- `fix: <what>`
-- `refactor: <what>`
-- `docs: <what>`
-- `test: <what>`
-- `chore: <what>`
+## Commit messages i tytuły PR-ów
+
+Tytuły PR-ów używają Conventional Commits ze scope'em wskazującym numer z nazwy brancha:
+- `feat(ocv-<numer>): <what>`
+- `fix(ocv-<numer>): <what>`
+- `refactor(ocv-<numer>): <what>`
+- `docs(ocv-<numer>): <what>`
+- `test(ocv-<numer>): <what>`
+- `chore(ocv-<numer>): <what>`
 
 Examples:
-- `docs: add prompt template and git rules`
-- `fix: enforce email verification on signin`
+- `feat(ocv-0123): add prompt template and git rules`
+- `fix(ocv-0155): enforce email verification on signin`
+
+Pojedyncze commity wewnątrz brancha mogą używać krótszej formy bez scope'u (`feat: <what>`, `fix: <what>`, ...) — imperative, present tense.
 
 Rule of thumb:
 - Keep commits atomic (one logical change).

--- a/docs/guides/development/local-development.md
+++ b/docs/guides/development/local-development.md
@@ -56,18 +56,16 @@ npm run dev
 
 ## Compatibility Redirects
 
-Netlify keeps permanent redirects from historical `.html` URLs such as `/login.html` and `/resume.html` to their React routes. The old static files themselves are no longer present in `public/`.
+The legacy static HTML application and its compatibility redirects are retired.
+Use the Next.js routes listed above. `netlify.toml` currently contains the build
+configuration and Next.js plugin, without historical `.html` redirect rules.
 
 ## Required migrations
 
-Apply SQL migrations in order:
-
-1. `supabase/migrations/20260405000000_phase_c_foundation.sql`
-2. `supabase/migrations/20260405010000_z_phase_c_completion.sql`
-3. `supabase/migrations/20260406000000_fix_profiles_policy_recursion.sql` (if required)
-4. `supabase/migrations/20260409000000_phase_d_yaml_template_iteration.sql`
-5. `supabase/migrations/20260410000000_phase_b_yaml_data_layer.sql`
-6. `supabase/migrations/20260410010000_phase_c_auth_rbac_admin.sql`
+Use the complete migration history in [supabase/migrations](../../../supabase/migrations)
+and the instructions in [README](../../../README.md#database-migrations).
+Apply pending migrations in filename/version order to the intended environment;
+the initial foundation migrations alone do not provide the current application schema.
 
 ## Validation
 

--- a/docs/guides/features/first-use-master-cv.md
+++ b/docs/guides/features/first-use-master-cv.md
@@ -5,6 +5,19 @@ scratch/import choice, the eleven existing Master Resume sections, a preview,
 and an explicit choice to create a published CV. Both English and Polish guide
 copy are available; the document language is selected independently.
 
+The guide fills the browser viewport and hides the application header, including
+its navigation, account menu and theme switch. It inherits the current editor
+theme and reuses the editor's fields and color tokens. Its brand is non-navigating;
+the explicit “Finish later” action saves before leaving the guide.
+
+A vertical axis on the left lists all fifteen steps. The current number is larger
+and highlighted; previous steps are marked separately. The axis reflects the
+current position, not a checklist of field completeness, and does not allow
+skipping validation or saving. On small screens it becomes a narrow numbered rail,
+with step labels still available to assistive technology. The rail can scroll on
+short viewports and keeps the active step visible. Completion shows 100 percent.
+Leaving onboarding restores the application's normal navigation.
+
 ## Enrollment and resumption
 
 Migration `20260907000000_resume_onboarding.sql` enrolls profiles inserted after
@@ -119,6 +132,9 @@ Manual User and Admin acceptance scenarios (Polish):
 [Onboarding test scenarios](../test-scenarios/ONBOARDING_TEST_SCENARIOS.md).
 
 - Default checks: `npm.cmd run lint`, `npm.cmd run typecheck`, `npm.cmd test`.
+- UI regression tests: `tests/onboarding-progress.test.mjs` renders every step,
+  backward movement, completion and localized labels; `tests/app-brand.test.mjs`
+  checks the non-navigating brand and unique SVG gradient IDs alongside the header.
 - Behavioral tests: `tests/resume-onboarding.test.mjs` covers enrollment decisions,
   input validation, owner scoping, role capabilities, publication consent, summary
   selection, failures, and retries without duplicate CVs.

--- a/docs/guides/test-scenarios/ONBOARDING_TEST_SCENARIOS.md
+++ b/docs/guides/test-scenarios/ONBOARDING_TEST_SCENARIOS.md
@@ -101,7 +101,10 @@ Język przewodnika oraz język dokumentu CV wybiera się niezależnie.
 
 **Oczekiwany wynik:** konto wymaga weryfikacji. Po zalogowaniu przejście na
 dashboard lub Master Resume prowadzi do `/onboarding`. Widoczne są logo,
-powitanie, wybór języka przewodnika i pasek postępu. Nie powstaje jeszcze CV
+powitanie, wybór języka przewodnika i pionowa oś postępu po lewej. Przewodnik
+zajmuje cały obszar strony w przeglądarce; globalna nawigacja, menu konta i
+przełącznik motywu są niewidoczne i niedostępne klawiaturą. Logo nie jest linkiem.
+Nie powstaje jeszcze CV
 z publicznym linkiem.
 
 ### U-02 — Utworzenie CV od zera i podgląd [P0]
@@ -162,6 +165,7 @@ nie oczekuj identycznego odtworzenia formatowania pliku źródłowego.
 1. W sekcji doświadczenia dodaj tekst `WZNOWIENIE-01`.
 2. Wybierz **Dokończę później / Finish later**.
 3. Na dashboardzie odszukaj możliwość wznowienia przewodnika.
+   Sprawdź również powrót globalnej nawigacji i menu konta po opuszczeniu przewodnika.
 4. Wyloguj się i zaloguj ponownie, opcjonalnie na drugim urządzeniu.
 5. Wznów przewodnik, przejdź do następnej planszy, a następnie odśwież stronę.
 
@@ -378,17 +382,31 @@ Jeżeli nie można zasymulować awarii po zapisie na serwerze, oznacz krok 3 jak
 wpisanej treści ani zmiany wybranego języka CV. Po zapisaniu kroku i odświeżeniu
 wybory pozostają. Publikacja udostępnia wybrany język dokumentu.
 
-### W-04 — Mały ekran, klawiatura i postęp [P1]
+### W-04 — Pełny ekran, klawiatura, motywy i pionowy postęp [P1]
 
 1. Sprawdź powitanie, import, formularz, podgląd i zakończenie przy szerokości
-   390 px oraz na komputerze.
-2. Przewiń długą planszę i sprawdź dostępność paska postępu.
+   320 px, 390 px, 768 px oraz na komputerze. Uwzględnij niski widok poziomy.
+2. Sprawdź oś po lewej: 15 numerowanych etapów, wyraźnie większy i podświetlony
+   numer bieżącej planszy. Przejdź dalej i cofnij się; oznaczenie ma podążać za planszą.
+   Sprawdź także końcowe etapy, które na niskim ekranie wymagają przewinięcia osi.
+   Oś jest wskaźnikiem — nie umożliwia pominięcia zapisu przez kliknięcie numeru.
 3. Przejdź pola i przyciski klawiszem Tab; uruchamiaj je klawiaturą.
 4. Zmień planszę i sprawdź położenie strony oraz fokus nagłówka.
+5. Przewiń długą planszę formularza; sprawdź, czy oś pozostaje przy lewej krawędzi
+   i bieżący etap jest widoczny.
+6. Przed wejściem w onboarding ustaw kolejno jasny i ciemny motyw aplikacji;
+   powtórz kontrolę wyglądu, czytelności aktywnego numeru i kompletności logo.
+7. Wyjdź przez Dokończę później. Sprawdź, czy dashboard i zwykły edytor ponownie
+   pokazują nawigację aplikacji i mają swój standardowy układ.
 
 **Oczekiwany wynik:** brak poziomego przewijania całej strony i zasłoniętych akcji.
-Postęp pozostaje widoczny podczas wypełniania. Fokus jest widoczny, kolejność
-klawiatury logiczna, a zmiana planszy przenosi widok na jej początek.
+Przewodnik wypełnia cały obszar strony, bez globalnego nagłówka i jego pustego miejsca.
+Na telefonie oś pozostaje po lewej jako wąska kolumna numerów; nazwa aktualnej sekcji
+jest widoczna nad formularzem. Postęp pozostaje dostępny podczas wypełniania,
+a aktywny numer mieści się w widocznym obszarze osi. Fokus jest widoczny, kolejność
+klawiatury logiczna, a zmiana planszy przenosi widok na jej początek. Kolory,
+pola i przyciski odpowiadają aktualnemu edytorowi CV w obu motywach. Układ pozostałych
+stron nie zmienia się po opuszczeniu przewodnika.
 
 ### W-05 — Zamknięcie strony z niezapisanymi zmianami [P1]
 

--- a/tests/app-brand.test.mjs
+++ b/tests/app-brand.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { createElement, Fragment } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+const { outputText } = ts.transpileModule(readFileSync("app/components/app-brand.tsx", "utf8"), {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, jsx: ts.JsxEmit.ReactJSX, esModuleInterop: true },
+});
+const module = { exports: {} };
+new Function("require", "module", "exports", outputText)(require, module, module.exports);
+const AppBrand = module.exports.default;
+
+test("the onboarding brand has no navigation while the default brand still links home", () => {
+  assert.doesNotMatch(renderToStaticMarkup(createElement(AppBrand, { href: null })), /<a\b/);
+  assert.match(renderToStaticMarkup(createElement(AppBrand)), /href="\/"/);
+});
+
+test("multiple brands have independent SVG gradients, including when one is hidden", () => {
+  const html = renderToStaticMarkup(createElement(Fragment, null,
+    createElement(AppBrand), createElement(AppBrand, { href: null }),
+  ));
+  const ids = [...html.matchAll(/<linearGradient id="([^"]+)"/g)].map(match => match[1]);
+  assert.equal(ids.length, 2);
+  assert.equal(new Set(ids).size, 2, "A hidden header must not hide the onboarding logo gradient");
+  for (const id of ids) assert.ok(html.includes(`url(#${id})`));
+});

--- a/tests/onboarding-progress.test.mjs
+++ b/tests/onboarding-progress.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+register("./helpers/ts-extension-resolve.mjs", import.meta.url);
+const { default: OnboardingProgress } = await import("../app/onboarding/onboarding-progress.tsx");
+const { ONBOARDING_SECTIONS } = await import("../app/lib/resume-onboarding.ts");
+const steps = ["Welcome", "Start", ...ONBOARDING_SECTIONS, "Review", "Publish"];
+const render = (step, finished = false) => renderToStaticMarkup(createElement(OnboardingProgress, {
+  steps, step, finished, label: "Guide progress", completeLabel: "Complete",
+}));
+
+test("the progress axis lists every step and marks only the current step", () => {
+  for (let step = 0; step < steps.length; step++) {
+    const html = render(step);
+    assert.equal((html.match(/<li\b/g) ?? []).length, steps.length);
+    assert.equal((html.match(/aria-current="step"/g) ?? []).length, 1);
+    const active = html.match(/<li\b[^>]*aria-current="step"[^>]*>([\s\S]*?)<\/li>/)?.[1];
+    assert.ok(active?.includes(steps[step]));
+    assert.ok(active?.includes(`>${step + 1}</span>`));
+    assert.equal((html.match(/data-state="complete"/g) ?? []).length, step);
+    assert.doesNotMatch(html, /<(a|button)\b/, "The axis must not bypass form validation or save actions");
+  }
+});
+
+test("going back reflects the current position without claiming the guide is complete", () => {
+  assert.match(render(13), /value="87"/);
+  assert.match(render(2), /value="13"/);
+  assert.match(render(14), /value="93"/);
+});
+
+test("completion marks all steps and exposes 100 percent without an active form step", () => {
+  const html = render(14, true);
+  assert.equal((html.match(/data-state="complete"/g) ?? []).length, steps.length);
+  assert.doesNotMatch(html, /aria-current="step"/);
+  assert.match(html, /value="100"/);
+  assert.match(html, /Complete/);
+});
+
+test("the progress axis uses supplied translated labels", () => {
+  const html = renderToStaticMarkup(createElement(OnboardingProgress, {
+    steps: ["Witaj", "Dane osobowe"], step: 1, finished: false,
+    label: "Postęp przewodnika", completeLabel: "Gotowe",
+  }));
+  assert.match(html, /aria-label="Postęp przewodnika"/);
+  assert.match(html, /Dane osobowe/);
+});


### PR DESCRIPTION
## Summary
- Adopts the `ocv-<numer>-<opis>` branch/PR naming convention (git-workflow.md + enforcing hook)
- Documents the CV import and first-use onboarding features in CLAUDE.md (previously undocumented), and flags that the raw-vs-normalized selection contract has now been violated twice
- Restructures Codex CLI instructions: `AGENTS.md` becomes the canonical entry point, `.codex/instructions.md` is now a compatibility pointer
- Adds an onboarding progress indicator (`app/onboarding/onboarding-progress.tsx`), plus an `AppBrand` fix (stable per-instance gradient id via `useId`, `href={null}` non-link mode)

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (570/571 passing, 1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxXP4R5bbTs3ffyfybNDuZ