### PR TITLE
fix(ocv-0165): course name before year in compact row

### DIFF
--- a/app/master-resume/editor-canvas-client.tsx
+++ b/app/master-resume/editor-canvas-client.tsx
@@ -996,8 +996,8 @@ export default function EditorCanvasClient({ draftPdfEnabled = true, onboarding,
                 <section className="resume-human-editor__section">
                   {resume.courses.map((item, index) => (
                     <div className="resume-human-editor__row resume-human-editor__row--compact" key={`course-${index}`}>
-                      <input type="number" min={0} aria-label={editorText("Year")} placeholder={editorText("Year")} value={item.year || 0} onChange={(event) => updateCourse(index, "year", event.target.value)} />
                       <input aria-label={editorText("Course name")} placeholder={editorText("Course name")} value={item.name} onChange={(event) => updateCourse(index, "name", event.target.value)} />
+                      <input type="number" min={0} aria-label={editorText("Year")} placeholder={editorText("Year")} value={item.year || 0} onChange={(event) => updateCourse(index, "year", event.target.value)} />
                       <button type="button" className="button button--danger button--small" onClick={() => removeArrayItem("courses", index)}>
                         {editorText("Remove")}
                       </button>

--- a/tests/editor-canvas-layout.test.mjs
+++ b/tests/editor-canvas-layout.test.mjs
@@ -97,3 +97,17 @@ test("add actions sit at the end of each list", () => {
   }
   assert.equal(editor.includes('className="resume-human-editor__add"'), true);
 });
+
+test("compact rows put the wide field before the narrow field", () => {
+  const editor = read("app/master-resume/editor-canvas-client.tsx");
+
+  // .resume-human-editor__row--compact is `minmax(160px, 1fr) minmax(80px, 120px) auto`
+  // (wide, narrow, remove button) — every field pair using it must follow that
+  // order, or the first field renders wide when it should be narrow (ocv-0165:
+  // the course row had Year before Course name, so Year got the wide column).
+  const skillsRow = editor.slice(editor.indexOf("resume.skills.map"), editor.indexOf("+ Add skill"));
+  assert.ok(skillsRow.indexOf('aria-label={editorText("Skill")}') < skillsRow.indexOf('aria-label={editorText("Level")}'));
+
+  const coursesRow = editor.slice(editor.indexOf("resume.courses.map"), editor.indexOf("+ Add course"));
+  assert.ok(coursesRow.indexOf('aria-label={editorText("Course name")}') < coursesRow.indexOf('aria-label={editorText("Year")}'));
+});


### PR DESCRIPTION
## Summary
- Onboarding/editor Courses row rendered Year before Course name; the `.resume-human-editor__row--compact` grid gives the first slot the wide column, so Year was wide and Course name narrow.
- Swaps the two inputs so Course name (wide) comes first, matching the Skills row.

## Test plan
- [x] `node --test tests/editor-canvas-layout.test.mjs` (added a regression assertion)
- [x] `npx tsc --noEmit`

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw