### PR TITLE
feat(ocv-0167): hide QR codes step from onboarding

### DIFF
--- a/app/lib/resume-onboarding.ts
+++ b/app/lib/resume-onboarding.ts
@@ -11,7 +11,6 @@ export const ONBOARDING_SECTIONS = [
   "courses",
   "interests",
   "tech-stack",
-  "qr-codes",
   "gdpr"
 ] as const;
 export const ONBOARDING_REVIEW_STEP = ONBOARDING_SECTIONS.length + 2;

--- a/app/onboarding/onboarding-client.tsx
+++ b/app/onboarding/onboarding-client.tsx
@@ -26,7 +26,6 @@ const TITLES = {
     "Courses",
     "Interests",
     "Tech stack",
-    "QR codes",
     "GDPR clause",
     "Review your first CV",
     "Ready to share your CV?"
@@ -43,7 +42,6 @@ const TITLES = {
     "Kursy",
     "Zainteresowania",
     "Technologie",
-    "Kody QR",
     "Klauzula RODO",
     "Sprawdź swoje pierwsze CV",
     "Udostępnisz swoje CV?"

--- a/tests/onboarding-progress.test.mjs
+++ b/tests/onboarding-progress.test.mjs
@@ -26,13 +26,13 @@ test("the progress axis lists every step and marks only the current step", () =>
 });
 
 test("going back reflects the current position without claiming the guide is complete", () => {
-  assert.match(render(13), /value="87"/);
-  assert.match(render(2), /value="13"/);
-  assert.match(render(14), /value="93"/);
+  assert.match(render(12), /value="86"/);
+  assert.match(render(2), /value="14"/);
+  assert.match(render(13), /value="93"/);
 });
 
 test("completion marks all steps and exposes 100 percent without an active form step", () => {
-  const html = render(14, true);
+  const html = render(13, true);
   assert.equal((html.match(/data-state="complete"/g) ?? []).length, steps.length);
   assert.doesNotMatch(html, /aria-current="step"/);
   assert.match(html, /value="100"/);


### PR DESCRIPTION
## Summary
- Removes the "QR codes" step from the onboarding guide (`ONBOARDING_SECTIONS` in `app/lib/resume-onboarding.ts`, titles in `app/onboarding/onboarding-client.tsx`).
- Master Resume editor is untouched — QR codes are still editable there.
- Step count drops 15 → 14; updated the hardcoded progress-bar percentages in `tests/onboarding-progress.test.mjs` accordingly.

## Test plan
- [x] `node --test tests/onboarding-progress.test.mjs tests/resume-onboarding.test.mjs`
- [x] `npx tsc --noEmit`

Known consideration (see issue): step numbers shift by one, so any account with an in-progress onboarding paused at/after the old QR step will resume one section title off. Acceptable at this beta stage (small number of testers).

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw