### PR TITLE
chore(ocv-0175): remove onboarding welcome checklist

### DIFF
--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -1067,13 +1067,6 @@ export default function DashboardClient({
                           </small>
                         </div>
                       </li>
-                      <li aria-current={selectedPreset.is_public ? "step" : undefined}>
-                        <span>3</span>
-                        <div>
-                          <strong>Share your CV</strong>
-                          <small>Send the link when ready</small>
-                        </div>
-                      </li>
                     </ol>
                     <div className="dashboard-next__actions">
                       <p>

--- a/app/onboarding/onboarding-client.tsx
+++ b/app/onboarding/onboarding-client.tsx
@@ -232,16 +232,6 @@ export default function OnboardingClient(props: Props) {
                 "Opowiedz o sobie, sekcja po sekcji. Pomożemy Ci uzupełnić Master CV i utworzyć CV, które udostępnisz za pomocą linku."
               )}
             </p>
-            <ol>
-              <li>{t("Import a CV or start from scratch", "Zaimportuj CV lub zacznij od zera")}</li>
-              <li>{t("Review and fill in your details", "Sprawdź i uzupełnij swoje dane")}</li>
-              <li>
-                {t(
-                  "Choose whether to create a shareable CV",
-                  "Zdecyduj, czy utworzyć CV z linkiem"
-                )}
-              </li>
-            </ol>
           </div>
         ) : null}
 


### PR DESCRIPTION
## Summary
- Removes the unmeasurable "Share your CV" step from **both** places matching the report's "What can you do next" section:
  - The onboarding welcome screen's 3-item checklist (`app/onboarding/onboarding-client.tsx`) — kept the intro paragraph, dropped the `<ol>`.
  - The dashboard's per-CV-version "What can you do next?" panel (`app/dashboard/dashboard-client.tsx`) — this is the literal heading match. Its step 3 ("Share your CV") never carried `data-complete`, so it could never be marked done; now the checklist only lists the two steps that actually have a completion state (choose content, review and publish).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `node --test tests/dashboard-presets.test.mjs`
- No existing test covered either markup block.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw