### PR TITLE
feat(ocv-0168): add EN wording option to GDPR clause

### DIFF
--- a/app/master-resume/editor-canvas-client.tsx
+++ b/app/master-resume/editor-canvas-client.tsx
@@ -63,11 +63,13 @@ import { defaultResumeDocument, initialsFromNameParts, resumeFullName } from "..
 
 type EditorTab = "yaml" | "human";
 
-// One-click starting point for the "GDPR clause" field. Users on the Polish
+// One-click starting points for the "GDPR clause" field. Users on the Polish
 // job market include this text verbatim; it is not an enum in the schema
 // (see gdpr_clause on ResumeDocument) — just a plain string a click can seed.
 const STANDARD_GDPR_CLAUSE =
   "Wyrażam zgodę na przetwarzanie moich danych osobowych zawartych w niniejszym dokumencie do realizacji procesu rekrutacji zgodnie z Rozporządzeniem Parlamentu Europejskiego i Rady (UE) 2016/679 z dnia 27 kwietnia 2016 r. (RODO).";
+const STANDARD_GDPR_CLAUSE_EN =
+  "I hereby give consent for my personal data included in this document to be processed for the purposes of the current recruitment process.";
 
 const EDITOR_STYLES: Array<{ code: ResumeEditorStyle; label: string }> = [
   { code: "basic", label: "basic" },
@@ -1023,6 +1025,9 @@ export default function EditorCanvasClient({ draftPdfEnabled = true, onboarding,
                   <div className="actions-row">
                     <button type="button" className="button button--ghost button--small" onClick={() => updateGdprClause(STANDARD_GDPR_CLAUSE)}>
                       {editorText("Use standard PL wording")}
+                    </button>
+                    <button type="button" className="button button--ghost button--small" onClick={() => updateGdprClause(STANDARD_GDPR_CLAUSE_EN)}>
+                      {editorText("Use standard EN wording")}
                     </button>
                     <button type="button" className="button button--ghost button--small" onClick={() => updateGdprClause("")}>
                       {editorText("Clear")}

--- a/tests/editor-canvas-layout.test.mjs
+++ b/tests/editor-canvas-layout.test.mjs
@@ -97,3 +97,13 @@ test("add actions sit at the end of each list", () => {
   }
   assert.equal(editor.includes('className="resume-human-editor__add"'), true);
 });
+
+test("GDPR clause has a one-click starting point for both PL and EN wording", () => {
+  const editor = read("app/master-resume/editor-canvas-client.tsx");
+
+  assert.equal(editor.includes("const STANDARD_GDPR_CLAUSE ="), true);
+  assert.equal(editor.includes("const STANDARD_GDPR_CLAUSE_EN ="), true);
+  assert.equal(editor.includes("Use standard PL wording"), true);
+  assert.equal(editor.includes("Use standard EN wording"), true);
+  assert.equal(editor.includes("updateGdprClause(STANDARD_GDPR_CLAUSE_EN)"), true);
+});


### PR DESCRIPTION
## Summary
- Adds `STANDARD_GDPR_CLAUSE_EN` and a "Use standard EN wording" button next to the existing PL one, in the Master Resume editor's GDPR clause section.
- `gdpr_clause` stays a free-text string — no schema change.

## Test plan
- [x] `node --test tests/editor-canvas-layout.test.mjs` (added a regression assertion)
- [x] `npx tsc --noEmit`

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw