### PR TITLE
fix(ocv-0177): master resume selection follows is_default, not hardcoded 'en'

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import WorkspaceBreadcrumbs from "../components/workspace-breadcrumbs";
 import { requireAuthenticatedActor } from "../lib/auth-server";
 import { isPdfDraftEnabled } from "../lib/pdf-feature-flags";
 import { isUserDataTransferEnabled } from "../lib/platform-feature-flags";
-import { bootstrapResumeUserLocales, fetchResumeDocumentsForUser, fetchResumePresetsForUser, fetchResumeUserLocalesForUser } from "../lib/resume-server";
+import { bootstrapResumeUserLocales, fetchResumeDocumentsForUser, fetchResumePresetsForUser, fetchResumeUserLocalesForUser, pickMasterResumeDocument } from "../lib/resume-server";
 
 export const dynamic = "force-dynamic";
 
@@ -29,7 +29,7 @@ export default async function DashboardPage() {
   ]);
   const ownedLocaleCodes = new Set(resumeLanguages.map((language) => language.code));
   const ownedDocuments = resumeDocuments.filter((document) => ownedLocaleCodes.has(document.locale));
-  const masterResume = ownedDocuments.find((document) => document.locale === "en") || ownedDocuments[0] || null;
+  const masterResume = pickMasterResumeDocument(ownedDocuments, resumeLanguages);
 
   return (
     <div className="dashboard-page editor-theme wide-shell-page">

--- a/app/lib/resume-server.ts
+++ b/app/lib/resume-server.ts
@@ -970,6 +970,25 @@ export async function fetchResumeLanguageVersionsForUser(userId: string): Promis
   }));
 }
 
+// The "master resume" is whichever document the user actually marked as
+// their default locale (resume_user_locales.is_default) — not a hardcoded
+// "en", which silently picked an empty English stub over a fully filled PL
+// document for PL-first accounts (ocv-0177: this broke Create CV Version,
+// the ATS score, and language switching, since every one of them treats
+// this document as the source of truth for section options/selection).
+export function pickMasterResumeDocument(
+  documents: ResumeDocumentRow[],
+  languages: Pick<ResumeUserLocaleRow, "code" | "is_default">[],
+): ResumeDocumentRow | null {
+  const defaultLocaleCode = languages.find((language) => language.is_default)?.code;
+  return (
+    documents.find((document) => document.locale === defaultLocaleCode) ||
+    documents.find((document) => document.locale === "en") ||
+    documents[0] ||
+    null
+  );
+}
+
 export function buildResumeDocumentFromPreset(yamlContent: string, selection: ResumePresetSelection): ResumeDocument | null {
   return buildPublishedResumeDocument(yamlContent, selection);
 }

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,7 +1,7 @@
 import Script from "next/script";
 import UserClient from "./user-client";
 import { requireAdminActor } from "../lib/auth-server";
-import { bootstrapResumeUserLocales, fetchResumeDocumentsForUser, fetchResumePresetsForUser, fetchResumeUserLocalesForUser } from "../lib/resume-server";
+import { bootstrapResumeUserLocales, fetchResumeDocumentsForUser, fetchResumePresetsForUser, fetchResumeUserLocalesForUser, pickMasterResumeDocument } from "../lib/resume-server";
 import "./user.css";
 
 export const dynamic = "force-dynamic";
@@ -16,7 +16,7 @@ export default async function UserPage() {
   ]);
   const ownedLocaleCodes = new Set(resumeLanguages.map((language) => language.code));
   const ownedDocuments = resumeDocuments.filter((document) => ownedLocaleCodes.has(document.locale));
-  const masterResume = ownedDocuments.find((document) => document.locale === "en") || ownedDocuments[0] || null;
+  const masterResume = pickMasterResumeDocument(ownedDocuments, resumeLanguages);
 
   return (
     <>

--- a/tests/resume-master-document-selection.test.mjs
+++ b/tests/resume-master-document-selection.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "node:module";
+
+register("./helpers/ts-extension-resolve.mjs", import.meta.url);
+
+const { pickMasterResumeDocument } = await import("../app/lib/resume-server.ts");
+
+function doc(locale) {
+  return { id: locale, user_id: "u1", locale, title: "", yaml_content: `locale: ${locale}`, schema_version: 1, updated_at: "" };
+}
+
+function lang(code, isDefault) {
+  return { code, is_default: isDefault };
+}
+
+test("picks the document whose locale is flagged as the user's default", () => {
+  // ocv-0177: a PL-first account (PL is_default, no "en" document at all)
+  // must resolve to the PL document, not silently fall through to null or
+  // an unrelated document.
+  const documents = [doc("pl")];
+  const languages = [lang("pl", true)];
+  assert.equal(pickMasterResumeDocument(documents, languages)?.locale, "pl");
+});
+
+test("prefers the flagged default over a coincidentally-present 'en' document", () => {
+  const documents = [doc("en"), doc("pl")];
+  const languages = [lang("en", false), lang("pl", true)];
+  assert.equal(pickMasterResumeDocument(documents, languages)?.locale, "pl");
+});
+
+test("falls back to 'en' when no language is flagged as default", () => {
+  const documents = [doc("pl"), doc("en")];
+  const languages = [lang("pl", false), lang("en", false)];
+  assert.equal(pickMasterResumeDocument(documents, languages)?.locale, "en");
+});
+
+test("falls back to the first document when nothing matches a locale", () => {
+  const documents = [doc("de")];
+  const languages = [];
+  assert.equal(pickMasterResumeDocument(documents, languages)?.locale, "de");
+});
+
+test("returns null for a brand-new account with no documents yet", () => {
+  assert.equal(pickMasterResumeDocument([], []), null);
+});


### PR DESCRIPTION
## Summary
- `app/dashboard/page.tsx` and `app/user/page.tsx` both picked the master resume with `documents.find(d => d.locale === "en") || documents[0]`, ignoring `resume_user_locales.is_default`. For a PL-first account this silently preferred a missing/empty English document over the real PL content.
- Everything downstream that reads `masterResume.yaml_content` (Create CV Version's option list, the dashboard ATS score preview, language switching) inherits whichever document this picks — so this one bug plausibly explains three separate reports: #177 (Create CV Version shows nothing to add), and contributes to #171 (ATS score shows 0) and #172 (language switch preview error).
- Extracted the duplicated logic into `pickMasterResumeDocument()` in `app/lib/resume-server.ts`, used by both pages.

## Test plan
- [x] New unit tests: `node --test tests/resume-master-document-selection.test.mjs`
- [x] `npx tsc --noEmit`
- [x] `npm test` (580 tests, 578 pass / 2 pre-existing skips, 0 failures)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw