### PR TITLE
fix(ocv-0174): move CV version actions above the preview

### DIFF
--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -979,42 +979,9 @@ export default function DashboardClient({
             <div className="dashboard-library__detail">
               {selectedPreset ? (
                 <>
-                  {selectedPreset.onboarding_test_run_id ? (
-                    <div className="dashboard-test-preview">
-                      <FileText size={40} aria-hidden="true" />
-                      <h3>{selectedPreset.title}</h3>
-                      <p>This CV uses a separate onboarding test draft.</p>
-                      <Link
-                        className="button button--primary"
-                        href={
-                          selectedPreset.canonical_public_path ||
-                          `/onboarding/test-cv/${selectedPreset.onboarding_test_run_id}`
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Open test CV
-                      </Link>
-                    </div>
-                  ) : masterResume && yamlReady ? (
-                    <PresetPreviewModal
-                      key={selectedPreset.id}
-                      inline
-                      masterResume={masterResume}
-                      documents={documents}
-                      languages={languageVersions}
-                      preset={selectedPreset}
-                      draftPdfEnabled={draftPdfEnabled}
-                      onClose={() => setPreviewPreset(selectedPreset)}
-                    />
-                  ) : (
-                    <p className="dashboard-library-empty">
-                      {documentError ||
-                        (masterResume
-                          ? "Loading CV preview…"
-                          : "Open your Master Resume to add content for this version.")}
-                    </p>
-                  )}
+                  {/* ocv-0174: actions render above the preview, next to where
+                      "Open CV" appears inside PresetPreviewModal below, instead
+                      of after the full CV render where they needed scrolling. */}
                   <section className="dashboard-next" aria-label="Next steps for selected CV">
                     <div className="dashboard-next__heading">
                       <div>
@@ -1112,6 +1079,42 @@ export default function DashboardClient({
                       </div>
                     </div>
                   </section>
+                  {selectedPreset.onboarding_test_run_id ? (
+                    <div className="dashboard-test-preview">
+                      <FileText size={40} aria-hidden="true" />
+                      <h3>{selectedPreset.title}</h3>
+                      <p>This CV uses a separate onboarding test draft.</p>
+                      <Link
+                        className="button button--primary"
+                        href={
+                          selectedPreset.canonical_public_path ||
+                          `/onboarding/test-cv/${selectedPreset.onboarding_test_run_id}`
+                        }
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Open test CV
+                      </Link>
+                    </div>
+                  ) : masterResume && yamlReady ? (
+                    <PresetPreviewModal
+                      key={selectedPreset.id}
+                      inline
+                      masterResume={masterResume}
+                      documents={documents}
+                      languages={languageVersions}
+                      preset={selectedPreset}
+                      draftPdfEnabled={draftPdfEnabled}
+                      onClose={() => setPreviewPreset(selectedPreset)}
+                    />
+                  ) : (
+                    <p className="dashboard-library-empty">
+                      {documentError ||
+                        (masterResume
+                          ? "Loading CV preview…"
+                          : "Open your Master Resume to add content for this version.")}
+                    </p>
+                  )}
                 </>
               ) : (
                 <div className="dashboard-library-empty">

--- a/tests/dashboard-presets.test.mjs
+++ b/tests/dashboard-presets.test.mjs
@@ -125,3 +125,16 @@ test("snapshot exports use canonical public paths only for dashboard and editor 
   assert.equal(userClient.includes('aria-label="Resume preview"'), true);
   assert.equal(userClient.includes("presetId="), false);
 });
+
+test("CV version actions (Edit selection, Publish, settings menu) render above the CV preview", () => {
+  // ocv-0174: these used to sit below the full inline CV render, which meant
+  // scrolling past the whole CV to reach "Edit selection" or the settings
+  // menu — both should be immediately visible next to "Open CV".
+  const client = read("app/dashboard/dashboard-client.tsx");
+
+  const nextSectionIndex = client.indexOf('<section className="dashboard-next"');
+  const previewIndex = client.indexOf("<PresetPreviewModal");
+  assert.ok(nextSectionIndex > -1, "dashboard-next section not found");
+  assert.ok(previewIndex > -1, "PresetPreviewModal render not found");
+  assert.ok(nextSectionIndex < previewIndex, "actions must render before the CV preview, not after it");
+});


### PR DESCRIPTION
## Summary
- The per-CV-version "What can you do next?" panel (Edit selection, Publish/Copy link, and the ⋮ settings menu with Edit/Publish/Export/Delete) rendered **below** the full inline CV preview — reaching any of these actions meant scrolling past the whole rendered CV.
- Reordered the two sibling blocks in `app/dashboard/dashboard-client.tsx` so the actions section renders first, directly above where "Open CV" appears in the preview panel.
- Pure JSX reorder — no component props, callbacks, or markup content changed.

## Test plan
- [x] `node --test tests/dashboard-presets.test.mjs` (added a regression assertion on render order)
- [x] `npx tsc --noEmit`
- [x] `npx eslint app/dashboard/dashboard-client.tsx --max-warnings=0`

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw