### PR TITLE
fix(ocv-0172): friendly message for a CV version's empty-language preview

### DIFF
--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -152,15 +152,27 @@ function normalizeSummarySelection(selection: ResumePresetSelection, options: Pr
 // The selection is built against the default-locale document; clamp it to the
 // previewed document so other language versions render the way publish stores
 // them, instead of failing on out-of-range indexes.
-function buildPresetResumeDocument(yamlContent: string, selection: ResumePresetSelection): ResumeDocument | null {
-  if (!yamlContent || !window.jsyaml) return null;
+type PresetPreviewResult =
+  | { status: "ok"; resume: ResumeDocument }
+  // ocv-0172: a language version that has no summary yet (e.g. a freshly
+  // added, still-empty locale) is a normal, expected state -- not a failure.
+  | { status: "empty" }
+  | { status: "error" };
+
+function buildPresetResumeDocument(yamlContent: string, selection: ResumePresetSelection): PresetPreviewResult {
+  if (!yamlContent || !window.jsyaml) return { status: "error" };
   try {
     const rawDocument = window.jsyaml.load(yamlContent);
+    if (!rawDocument || typeof rawDocument !== "object" || Array.isArray(rawDocument)) {
+      return { status: "error" };
+    }
     const clampedSelection = clampResumeSelectionToRawDocument(rawDocument, selection);
-    const selectedRaw = clampedSelection ? applyResumeSelectionToRawDocument(rawDocument, clampedSelection) : null;
-    return selectedRaw ? normalizeResumeDocument(selectedRaw, "") : null;
+    if (!clampedSelection) return { status: "empty" };
+    const selectedRaw = applyResumeSelectionToRawDocument(rawDocument, clampedSelection);
+    if (!selectedRaw) return { status: "error" };
+    return { status: "ok", resume: normalizeResumeDocument(selectedRaw, "") };
   } catch {
-    return null;
+    return { status: "error" };
   }
 }
 
@@ -348,7 +360,7 @@ function PresetPreviewModal({
     availableDocuments.find((document) => document.locale === masterResume.locale) ||
     masterResume;
   const publicLink = parseCanonicalPublicPath(preset.canonical_public_path);
-  const previewResume = useMemo(
+  const previewResult = useMemo(
     () => buildPresetResumeDocument(activeDocument.yaml_content, preset.selection),
     [activeDocument.yaml_content, preset.selection],
   );
@@ -387,11 +399,33 @@ function PresetPreviewModal({
             Selected content from your current Master Resume. Published links and exports use the last publication.
           </p>
         ) : null}
-        {previewResume ? (
+        {previewResult.status !== "ok" ? (
+          <div className="dashboard-library-preview__fallback">
+            {cvLanguages.length > 1 ? (
+              <div className="actions-row">
+                {cvLanguages.map((language) => (
+                  <button
+                    key={language.code}
+                    type="button"
+                    className={`button button--small ${language.code === activeLocale ? "button--primary" : "button--ghost"}`}
+                    onClick={() => setActiveLocale(language.code)}
+                  >
+                    {language.label}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            <p className={previewResult.status === "empty" ? "dashboard-library-preview__note" : "status status--error"}>
+              {previewResult.status === "empty"
+                ? `This CV version has no content in ${cvLanguages.find((language) => language.code === activeDocument.locale)?.label || activeDocument.locale.toUpperCase()} yet. Add it in your Master Resume, or switch to a language you've filled in.`
+                : "CV preview could not be rendered from the master resume."}
+            </p>
+          </div>
+        ) : (
           <div ref={previewContainerRef} className="dashboard-preset-preview">
             <BasicResumeDocument
               locale={activeDocument.locale}
-              resume={previewResume}
+              resume={previewResult.resume}
               languages={cvLanguages}
               onLanguageSelect={setActiveLocale}
               status={preset.is_public ? "public" : "draft"}
@@ -404,8 +438,6 @@ function PresetPreviewModal({
               scrollContainerRef={previewContainerRef as React.RefObject<HTMLElement>}
             />
           </div>
-        ) : (
-          <p className="status status--error">CV preview could not be rendered from the master resume.</p>
         )}
       </div>
     </div>

--- a/tests/dashboard-presets.test.mjs
+++ b/tests/dashboard-presets.test.mjs
@@ -125,3 +125,23 @@ test("snapshot exports use canonical public paths only for dashboard and editor 
   assert.equal(userClient.includes('aria-label="Resume preview"'), true);
   assert.equal(userClient.includes("presetId="), false);
 });
+
+test("switching to a language version with no content shows a clear message, not a generic error", () => {
+  // ocv-0172: viewing a Saved Version in a language whose Master Resume tab
+  // is still empty used to show "CV preview could not be rendered from the
+  // master resume" — a scary, technical-sounding message for a normal state
+  // (that language just has nothing written yet), and it also removed the
+  // language switcher, trapping the viewer on the broken language.
+  const client = read("app/dashboard/dashboard-client.tsx");
+
+  assert.equal(client.includes('{ status: "ok"; resume: ResumeDocument }'), true);
+  assert.equal(client.includes('{ status: "empty" }'), true);
+  assert.equal(client.includes("has no content in"), true);
+  // The language-switch buttons must still render in the empty/error state,
+  // so the viewer isn't stuck once a switch fails.
+  const fallback = client.slice(
+    client.indexOf('previewResult.status !== "ok" ?'),
+    client.indexOf("</div>\n        ) : (\n          <div ref={previewContainerRef}"),
+  );
+  assert.equal(fallback.includes("setActiveLocale(language.code)"), true);
+});


### PR DESCRIPTION
## Summary
Reproduced live on production (opencivera.com): switching a Saved Version's preview to a language whose Master Resume tab has no content yet showed **"CV preview could not be rendered from the master resume"** — a scary, technical-sounding message for what is actually a normal state — and the language switcher itself disappeared (it lives inside `BasicResumeDocument`, which wasn't being mounted), trapping the viewer on the broken language.

Root cause: a preset's `selection` is raw-domain indexes computed against one specific document (its `default_locale`); the preview reapplies that same selection to whatever document the switcher points at. `clampResumeSelectionToRawDocument` correctly returns `null` when the target document has zero summary entries — that's the "this language is empty" signal, previously indistinguishable from a real parse/apply failure.

`buildPresetResumeDocument` (`app/dashboard/dashboard-client.tsx`) now returns a tagged `{status: "ok" | "empty" | "error"}` result instead of `null`, so the two cases render differently:
- **empty**: "This CV version has no content in {language} yet. Add it in your Master Resume, or switch to a language you've filled in." + the language-switch buttons (kept visible, so you're never stuck).
- **error**: the original message, for genuine failures.

## Test plan
- [x] Reproduced live on production, verified the fix addresses the exact repro
- [x] `node --test tests/dashboard-presets.test.mjs` (added a regression test)
- [x] `npx tsc --noEmit`
- [x] `npx eslint app/dashboard/dashboard-client.tsx tests/dashboard-presets.test.mjs --max-warnings=0`

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw