### PR TITLE
feat(ocv-0170): explain onboarding finished-screen actions, add PDF download

### DIFF
--- a/app/onboarding/onboarding-client.tsx
+++ b/app/onboarding/onboarding-client.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import AppBrand from "../components/app-brand";
 import OnboardingProgress from "./onboarding-progress";
+import { buildPublishedResumeExportUrls } from "../lib/resume-export";
 import {
   ONBOARDING_PUBLISH_STEP,
   ONBOARDING_REVIEW_STEP,
@@ -437,12 +438,37 @@ export default function OnboardingClient(props: Props) {
                   >
                     {t("Open CV", "Otwórz CV")}
                   </Link>
+                  {(() => {
+                    const exportUrls = buildPublishedResumeExportUrls(publicPath, locale);
+                    return exportUrls ? (
+                      <Link
+                        className="button button--ghost"
+                        href={exportUrls.pdfUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {t("Download PDF", "Pobierz PDF")}
+                      </Link>
+                    ) : null;
+                  })()}
                 </div>
+                <p className="onboarding__hint">
+                  {t(
+                    "Copy link or Open CV send/show the live page. Download PDF opens a printable copy in a new tab.",
+                    "Kopiuj link i Otwórz CV dotyczą żywej strony. Pobierz PDF otwiera w nowej karcie wersję do wydruku."
+                  )}
+                </p>
               </>
             ) : null}
             <Link className="button button--primary" href="/dashboard">
               {t("Go to dashboard", "Przejdź do dashboardu")}
             </Link>
+            <p className="onboarding__hint">
+              {t(
+                "Manage this and every future CV version — edit, publish, or delete — from your dashboard.",
+                "W dashboardzie zarządzasz tym i każdym kolejnym CV — edytujesz, publikujesz lub usuwasz."
+              )}
+            </p>
             {props.testRunId ? <Link className="button button--ghost" href="/settings">{t("Testing settings", "Ustawienia testowania")}</Link> : null}
           </div>
         ) : (

--- a/tests/onboarding-final-screen.test.mjs
+++ b/tests/onboarding-final-screen.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+test("finished onboarding screen explains each action and offers a PDF download", () => {
+  // ocv-0170: the finished screen had three actions (copy link, open CV, go
+  // to dashboard) with no explanation of what each does, and no way to get a
+  // PDF at all. Every action now has a one-line caption, and Download PDF
+  // reuses the same published-export URL builder every other export surface
+  // uses (never a bespoke URL).
+  const client = read("app/onboarding/onboarding-client.tsx");
+
+  assert.equal(client.includes("import { buildPublishedResumeExportUrls }"), true);
+  assert.equal(client.includes("Download PDF"), true);
+  assert.equal(client.includes("exportUrls.pdfUrl"), true);
+  assert.equal(client.includes("live page"), true);
+  assert.equal(client.includes("Manage this and every future CV version"), true);
+});


### PR DESCRIPTION
## Summary
- The onboarding finished screen had three unlabeled actions (Copy link, Open CV, Go to dashboard) with no explanation of what each does.
- Added a one-line caption after the link actions ("Copy link or Open CV send/show the live page...") and after the dashboard button ("Manage this and every future CV version...").
- Added a **Download PDF** button next to Copy link/Open CV, reusing `buildPublishedResumeExportUrls()` (`app/lib/resume-export.ts`) — the same URL builder every other export surface already uses — rather than inventing a new URL scheme. Opens in a new tab (a "preview" per the report).

## Not verified live
The test account had already completed onboarding, and this session has no admin access to `/settings`'s onboarding-test harness (asked the reporter; they opted to skip live verification for this one). Verified instead via:
- [x] `npx tsc --noEmit`
- [x] `npx eslint app/onboarding/onboarding-client.tsx --max-warnings=0`
- [x] `node --test tests/onboarding-final-screen.test.mjs` (new regression test)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x6RsqkyqxFmEJmKo3KKdw